### PR TITLE
Update type check for mala_step_size in jim.py

### DIFF
--- a/src/jimgw/core/jim.py
+++ b/src/jimgw/core/jim.py
@@ -92,7 +92,7 @@ class Jim(object):
             n_training_loops=n_training_loops,
             n_production_loops=n_production_loops,
             n_epochs=n_epochs,
-            mala_step_size=mala_step_size,  # type: ignore
+            mala_step_size=mala_step_size,  # type: ignore # Type ignored should be removed once the FlowMC fix is published
             chain_batch_size=chain_batch_size,
             rq_spline_hidden_units=rq_spline_hidden_units,
             rq_spline_n_bins=rq_spline_n_bins,


### PR DESCRIPTION
`mala_step_size` can be a 2D array. The type check in `FlowMC` is not updated yet.