### PR TITLE
Fix relative-binning bin placement to use standard PN phase powers (7/3)

### DIFF
--- a/src/jimgw/core/single_event/likelihood.py
+++ b/src/jimgw/core/single_event/likelihood.py
@@ -806,7 +806,7 @@ class HeterodynedTransientLikelihoodFD(SingleEventLikelihood):
 
         See Eq.(7) in arXiv:2302.05333.
         """
-        gamma = jnp.arange(-5, 6) / 3.0
+        gamma = jnp.array([-5.0 / 3, -2.0 / 3, 1.0, 5.0 / 3, 7.0 / 3])
         freq_2D = jax.lax.broadcast_in_dim(freqs, (freqs.size, gamma.size), [0])
         f_star = jnp.where(gamma >= 0, f_high, f_low)
         summand = (freq_2D / f_star) ** gamma * jnp.sign(gamma)


### PR DESCRIPTION
## What

`HeterodynedTransientLikelihoodFD.max_phase_diff` placed relative-binning bins using a uniform set of chirp-phase exponents `gamma = arange(-5, 6)/3`, which **omits the `7/3` PN power** (the highest, and dominant at high frequency). bilby / Zackay+2018 use `[-5/3, -2/3, 1, 5/3, 7/3]`.

## Why it matters

Because `7/3` dominates the phase at high frequency, jim accumulated too little phase there and allocated **coarser bins at high f**. For long BNS signals at high bin counts (e.g. GW170817, ~5000 bins) this under-resolves exactly the band where the `2*pi*f*dt_c` ramp lives, biasing the `t_c` posterior — an effect bilby does not show.

## Change (one line, `max_phase_diff`)

```diff
-        gamma = jnp.arange(-5, 6) / 3.0
+        gamma = jnp.array([-5.0 / 3, -2.0 / 3, 1.0, 5.0 / 3, 7.0 / 3])
```

With this, jim's bin edges match bilby's to ~1e-13 Hz.

## Bin placement — GW170817-like (23–2048 Hz, 5000 bins)

<!-- drag bin_placement_gamma_fix.png into the box below -->

| edges above | before | after (= bilby) |
|---|---|---|
| 500 Hz  | 1995 | 2742 |
| 1000 Hz | 1340 | 2080 |
| 1500 Hz | 712  | 1217 |

Before the fix jim's bins are ~1.9× wider than bilby's near 2 kHz; after, the two bin grids coincide.

## Tests

Heterodyne unit + bilby cross-validation tests pass (15/15).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the calculation used for transient phase difference estimates, making the result more consistent and predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->