### PR TITLE
Add multi-device sharding for NSS and SwiG

### DIFF
--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -354,6 +354,7 @@ n_tempered_steps = 5
 | `n_delete_frac` | `0.5` | Fraction of live points replaced per iteration |
 | `num_inner_steps_per_dim` | `10` | Slice steps per dimension for the nested kernel |
 | `termination_dlogz` | `0.1` | Stop when the remaining log-evidence contribution falls below this |
+| `n_devices` | `1` | Number of local devices used to shard live points; `n_live` and `n_delete` must be divisible by it |
 | `checkpoint_dir` | `{output.dir}/` | Directory for `checkpoint.pkl`; set by the CLI automatically |
 | `checkpoint_interval` | `600.0` | Seconds between checkpoint writes; `0` disables checkpointing |
 
@@ -369,6 +370,7 @@ n_tempered_steps = 5
 | `max_steps` | `10` | Maximum stepping-out expansions per slice |
 | `max_shrinkage` | `100` | Maximum shrinkage evaluations per slice |
 | `termination_dlogz` | `exp(-3)` (~`0.0498`) | Stop when the remaining evidence contribution falls below this |
+| `n_devices` | `1` | Number of local devices used to shard live points; `n_live` and `n_delete` must be divisible by it |
 | `checkpoint_dir` | `{output.dir}/` | Directory for `checkpoint.pkl`; set by the CLI automatically |
 | `checkpoint_interval` | `600.0` | Seconds between checkpoint writes; `0` disables checkpointing |
 

--- a/docs/guides/samplers.md
+++ b/docs/guides/samplers.md
@@ -220,6 +220,14 @@ Key parameters:
   replacement chains. The waveform cache remains local to each replacement
   chain; only live-point state participates in collectives.
 
+!!! tip "Sharding without a GPU/TPU cluster"
+    `n_devices` shards across whatever JAX reports as local devices — it does
+    not require accelerators. On a CPU-only host, set
+    `XLA_FLAGS=--xla_force_host_platform_device_count=N` (before JAX
+    initializes; the CPU device count cannot change at runtime) to expose `N`
+    simulated CPU devices and shard across them. See
+    [`examples/GW150914_NSS_sharded.py`](https://github.com/GW-JAX-Team/Jim/blob/main/examples/GW150914_NSS_sharded.py).
+
 ---
 
 ## Checkpointing and resuming

--- a/docs/guides/samplers.md
+++ b/docs/guides/samplers.md
@@ -149,6 +149,7 @@ jim = Jim(
         n_delete_frac=0.5,
         num_inner_steps_per_dim=20,
         termination_dlogz=0.1,
+        n_devices=1,
     ),
     sample_transforms=sample_transforms,
     likelihood_transforms=likelihood_transforms,
@@ -162,6 +163,9 @@ Key parameters:
 - `n_live` — number of live points.
 - `n_delete_frac` — fraction of live points replaced per iteration.
 - `num_inner_steps_per_dim` — slice-sampler steps per dimension per dead point; increase for strongly correlated posteriors.
+- `n_devices` — number of local devices used to shard the live points and
+  replacement chains. Both `n_live` and `int(n_live * n_delete_frac)` must be
+  divisible by this value. The default `1` uses the unsharded kernel.
 
 **Repository:** [blackjax-devs/blackjax](https://github.com/blackjax-devs/blackjax)
 
@@ -202,6 +206,7 @@ jim = Jim(
         num_inner_steps_per_dim=1,
         num_gibbs_sweeps=2,
         termination_dlogz=math.exp(-3.0),
+        n_devices=1,
     ),
     likelihood_transforms=likelihood_transforms,
 )
@@ -218,6 +223,9 @@ Key parameters:
 - `n_live` / `n_delete_frac` — live-set size and replacement fraction, matching NSS.
 - `num_inner_steps_per_dim` — random-direction slice steps per block dimension.
 - `num_gibbs_sweeps` — complete block sweeps per particle replacement.
+- `n_devices` — number of local devices used to shard the live points and
+  replacement chains. The waveform cache remains local to each replacement
+  chain; only live-point state participates in collectives.
 
 ---
 

--- a/examples/GW150914_NSS_sharded.py
+++ b/examples/GW150914_NSS_sharded.py
@@ -1,0 +1,162 @@
+"""GW150914 analysis with the BlackJAX NSS sampler, sharded across simulated CPU devices.
+
+Identical to `GW150914_NSS.py` except for two additions: the `XLA_FLAGS`
+environment variable (set *before* `jax` is imported — JAX's device count is
+fixed at process start and cannot change afterward) and `n_devices` on the
+sampler config. On a real multi-GPU/TPU host, drop the `XLA_FLAGS` line
+entirely; each accelerator is already visible to JAX as its own device.
+"""
+
+import os
+
+# Must be set before `jax` (or anything importing it) is loaded.
+os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
+
+import time
+from pathlib import Path
+
+import corner
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+jax.config.update("jax_enable_x64", True)
+
+print(f"Sharding live points across {jax.local_device_count()} simulated CPU devices.")
+
+from jimgw.core.jim import Jim
+from jimgw.core.prior import (
+    CombinePrior,
+    UniformPrior,
+    CosinePrior,
+    SinePrior,
+    PowerLawPrior,
+)
+from jimgw.core.single_event.detector import get_H1, get_L1
+from jimgw.core.single_event.likelihood import TransientLikelihoodFD
+from jimgw.core.single_event.data import Data
+from jimgw.core.single_event.waveform import RippleIMRPhenomXAS
+from jimgw.core.single_event.transforms import (
+    SkyFrameToDetectorFrameSkyPositionTransform,
+    MassRatioToSymmetricMassRatioTransform,
+    GeocentricArrivalTimeToDetectorArrivalTimeTransform,
+)
+from jimgw.samplers.config import BlackJAXNSSConfig
+
+
+# --- Fetch data ---
+
+gps = 1126259462.4
+duration = 4.0
+start = gps + 2.0 - duration
+end = start + duration
+
+psd_start = start - 2048
+psd_end = start
+
+fmin = 20.0
+fmax = 896.0
+
+ifos = [get_H1(), get_L1()]
+
+for ifo in ifos:
+    data = Data.from_gwosc(ifo.name, start, end)
+    ifo.set_data(data)
+
+    psd_data = Data.from_gwosc(ifo.name, psd_start, psd_end)
+    ifo.set_psd(psd_data.to_psd(nperseg=int(data.duration * data.sampling_frequency)))
+
+# --- Waveform model ---
+
+waveform = RippleIMRPhenomXAS(f_ref=20)
+
+# --- Prior ---
+
+prior = CombinePrior(
+    [
+        UniformPrior(20.0, 40.0, parameter_names=["M_c"]),
+        UniformPrior(0.125, 1.0, parameter_names=["q"]),
+        UniformPrior(-0.99, 0.99, parameter_names=["s1_z"]),
+        UniformPrior(-0.99, 0.99, parameter_names=["s2_z"]),
+        SinePrior(parameter_names=["iota"]),
+        PowerLawPrior(1.0, 2000.0, 2.0, parameter_names=["d_L"]),
+        UniformPrior(-0.1, 0.1, parameter_names=["t_c"]),
+        UniformPrior(0.0, jnp.pi, parameter_names=["psi"]),
+        UniformPrior(0.0, 2 * jnp.pi, parameter_names=["ra"]),
+        CosinePrior(parameter_names=["dec"]),
+    ]
+)
+
+# --- Transforms ---
+
+sample_transforms = [
+    GeocentricArrivalTimeToDetectorArrivalTimeTransform(trigger_time=gps, ifo=ifos[0]),
+    SkyFrameToDetectorFrameSkyPositionTransform(trigger_time=gps, ifos=ifos),
+]
+
+likelihood_transforms = [
+    MassRatioToSymmetricMassRatioTransform,
+]
+
+# --- Likelihood ---
+
+likelihood = TransientLikelihoodFD(
+    ifos,
+    waveform=waveform,
+    trigger_time=gps,
+    f_min=fmin,
+    f_max=fmax,
+    phase_marginalization=True,
+)
+
+# --- Sample ---
+
+jim = Jim(
+    likelihood,
+    prior,
+    sample_transforms=sample_transforms,
+    likelihood_transforms=likelihood_transforms,
+    periodic={
+        "psi": (0.0, float(jnp.pi)),
+        "azimuth": (0.0, 2 * float(jnp.pi)),
+    },
+    sampler_config=BlackJAXNSSConfig(
+        n_live=2000,
+        n_delete_frac=0.5,
+        num_inner_steps_per_dim=20,
+        termination_dlogz=0.1,
+        n_devices=4,  # n_live and int(n_live * n_delete_frac) must divide evenly.
+    ),
+)
+
+start_time = time.time()
+jim.sample()
+end_time = time.time()
+print(f"Sampling took {(end_time - start_time) / 60:.2f} mins")
+
+# --- Results ---
+
+diagnostics = jim.get_diagnostics()
+print(f"log Z = {diagnostics['log_Z']:.2f} ± {diagnostics['log_Z_error']:.2f}")
+print(f"Likelihood evaluations: {diagnostics['n_likelihood_evaluations']:,}")
+
+chains = jim.get_samples()
+
+parameter_labels = {
+    "M_c": r"$\mathcal{M}_c\,[M_\odot]$",
+    "q": r"$q$",
+    "s1_z": r"$s_{1,z}$",
+    "s2_z": r"$s_{2,z}$",
+    "iota": r"$\iota$",
+    "d_L": r"$d_L\,[\mathrm{Mpc}]$",
+    "t_c": r"$t_c\,[\mathrm{s}]$",
+    "psi": r"$\psi$",
+    "ra": r"$\alpha$",
+    "dec": r"$\delta$",
+}
+
+fig = corner.corner(
+    np.stack([chains[key] for key in jim.prior.parameter_names]).T,
+    labels=[parameter_labels.get(k, k) for k in jim.prior.parameter_names],
+)
+fig.savefig(Path(__file__).parent / "GW150914_NSS_sharded.png")

--- a/src/jimgw/samplers/blackjax/ns_aw.py
+++ b/src/jimgw/samplers/blackjax/ns_aw.py
@@ -171,6 +171,7 @@ class BlackJAXNSAWSampler(Sampler):
             and config.checkpoint_interval > 0
             and ckpt_path.exists()
         ):
+            _initial_rng_key = rng_key
             try:
                 with open(ckpt_path, "rb") as _f:
                     _ckpt = pickle.load(_f)
@@ -200,6 +201,7 @@ class BlackJAXNSAWSampler(Sampler):
                     ckpt_path,
                     _e,
                 )
+                rng_key = _initial_rng_key
                 state = nested_sampler.init(
                     _validated_initial_particles(initial_position)
                 )  # type: ignore[call-arg]  # blackjax API

--- a/src/jimgw/samplers/blackjax/nss.py
+++ b/src/jimgw/samplers/blackjax/nss.py
@@ -13,7 +13,7 @@ import numpy as np
 from anesthetic.samples import NestedSamples
 from jaxtyping import Array, Float, Key
 
-import blackjax
+from blackjax import SamplingAlgorithm, nss
 from blackjax.ns.adaptive import AdaptiveNSState, init as _ns_adaptive_init
 from blackjax.ns.base import NSInfo, init_state_strategy as _init_state_strategy
 from blackjax.ns.nss import (
@@ -27,6 +27,7 @@ from blackjax.mcmc.slice import stepping_out
 from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
 from jimgw.samplers.base import Sampler
 from jimgw.samplers.blackjax.sharding import (
+    _LIVE_AXIS,
     build_sharded_from_mcmc_kernel,
     make_live_mesh,
     place_key,
@@ -97,7 +98,7 @@ class BlackJAXNSSSampler(Sampler):
     def _update_inner_kernel_params_fn(self) -> Callable:
         return live_covariance
 
-    def _build_nested_sampler(self, n_delete: int, mesh: Mesh | None = None):
+    def _build_nested_sampler(self, n_delete: int, mesh: Optional[Mesh] = None):
         config = self._config
         num_inner_steps = config.num_inner_steps_per_dim * self.n_dims
         if mesh is not None:
@@ -121,10 +122,14 @@ class BlackJAXNSSSampler(Sampler):
                 n_delete=n_delete,
                 mesh=mesh,
             )
-            return blackjax.SamplingAlgorithm(
-                lambda position, rng_key=None: position, kernel
+            # `nested_sampler.init` is never called (state init happens in
+            # `_batched_nss_init`); BlackJAX still requires SamplingAlgorithm.init
+            # to type as returning a State.
+            return SamplingAlgorithm(
+                lambda position, rng_key=None: position,  # type: ignore[return-value]
+                kernel,
             )
-        return blackjax.nss(
+        return nss(
             logprior_fn=self._log_prior_fn,
             loglikelihood_fn=self._log_likelihood_fn,
             num_delete=n_delete,
@@ -190,7 +195,9 @@ class BlackJAXNSSSampler(Sampler):
 
         def _batched_nss_init(positions):
             if mesh is not None:
-                positions = jax.device_put(positions, NamedSharding(mesh, P("live")))
+                positions = jax.device_put(
+                    positions, NamedSharding(mesh, P(_LIVE_AXIS))
+                )
 
             def _batched_fn(pos):
                 return jax.lax.map(_single_init_fn, pos, batch_size=n_delete)

--- a/src/jimgw/samplers/blackjax/nss.py
+++ b/src/jimgw/samplers/blackjax/nss.py
@@ -16,9 +16,22 @@ from jaxtyping import Array, Float, Key
 import blackjax
 from blackjax.ns.adaptive import AdaptiveNSState, init as _ns_adaptive_init
 from blackjax.ns.base import NSInfo, init_state_strategy as _init_state_strategy
-from blackjax.ns.nss import live_covariance, sample_direction_from_covariance
+from blackjax.ns.nss import (
+    live_covariance,
+    sample_direction_from_covariance,
+    slice_constrained_step,
+)
 from blackjax.ns.utils import finalise
+from blackjax.mcmc.slice import build_kernel as build_slice_kernel
+from blackjax.mcmc.slice import stepping_out
+from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
 from jimgw.samplers.base import Sampler
+from jimgw.samplers.blackjax.sharding import (
+    build_sharded_from_mcmc_kernel,
+    make_live_mesh,
+    place_key,
+    place_state,
+)
 from jimgw.samplers.config import BlackJAXNSSConfig
 from jimgw.samplers.periodic import to_prior_space_proposal
 
@@ -84,9 +97,33 @@ class BlackJAXNSSSampler(Sampler):
     def _update_inner_kernel_params_fn(self) -> Callable:
         return live_covariance
 
-    def _build_nested_sampler(self, n_delete: int):
+    def _build_nested_sampler(self, n_delete: int, mesh: Mesh | None = None):
         config = self._config
         num_inner_steps = config.num_inner_steps_per_dim * self.n_dims
+        if mesh is not None:
+            init_state_fn = partial(
+                _init_state_strategy,
+                logprior_fn=self._log_prior_fn,
+                loglikelihood_fn=self._log_likelihood_fn,
+            )
+            slice_kernel = build_slice_kernel(
+                interval=stepping_out,
+                max_expansions=10,
+                max_shrinkage=100,
+            )
+            constrained_step = slice_constrained_step(
+                init_state_fn, slice_kernel, self._proposal
+            )
+            kernel = build_sharded_from_mcmc_kernel(
+                constrained_step,
+                n_inner_steps=num_inner_steps,
+                update_inner_kernel_params_fn=self._update_inner_kernel_params_fn,
+                n_delete=n_delete,
+                mesh=mesh,
+            )
+            return blackjax.SamplingAlgorithm(
+                lambda position, rng_key=None: position, kernel
+            )
         return blackjax.nss(
             logprior_fn=self._log_prior_fn,
             loglikelihood_fn=self._log_likelihood_fn,
@@ -120,6 +157,7 @@ class BlackJAXNSSSampler(Sampler):
         config = self._config
         n_live = config.n_live
         n_delete = int(n_live * config.n_delete_frac)
+        mesh = make_live_mesh(config.n_devices, n_live, n_delete)
         ckpt_path = (
             config.checkpoint_dir / "checkpoint.pkl"
             if config.checkpoint_dir is not None
@@ -137,7 +175,7 @@ class BlackJAXNSSSampler(Sampler):
                 )
             return arr
 
-        nested_sampler = self._build_nested_sampler(n_delete)
+        nested_sampler = self._build_nested_sampler(n_delete, mesh)
 
         # Bypass BlackJAX's jax.vmap(init_state_fn) to avoid peak-memory OOM.
         # A full vmap over all live particles materialises O(n_live) concurrent
@@ -151,14 +189,18 @@ class BlackJAXNSSSampler(Sampler):
         )
 
         def _batched_nss_init(positions):
+            if mesh is not None:
+                positions = jax.device_put(positions, NamedSharding(mesh, P("live")))
+
             def _batched_fn(pos):
                 return jax.lax.map(_single_init_fn, pos, batch_size=n_delete)
 
-            return _ns_adaptive_init(
+            state = _ns_adaptive_init(
                 positions,
                 init_state_fn=_batched_fn,
                 update_inner_kernel_params_fn=self._update_inner_kernel_params_fn,
             )
+            return place_state(state, mesh) if mesh is not None else state
 
         # Resume from checkpoint if one exists.
         if (
@@ -172,6 +214,9 @@ class BlackJAXNSSSampler(Sampler):
                 state = _ckpt["state"]
                 dead = _ckpt["dead"]
                 rng_key = _ckpt["rng_key"]
+                if mesh is not None:
+                    state = place_state(state, mesh)
+                    rng_key = place_key(rng_key, mesh)
                 n_iter = _ckpt["n_iter"]
                 self._prev_elapsed = float(_ckpt["elapsed_time"])
                 logger.info(
@@ -204,6 +249,9 @@ class BlackJAXNSSSampler(Sampler):
             dead = []
             n_iter = 0
 
+        if mesh is not None:
+            rng_key = place_key(rng_key, mesh)
+
         def _terminate(state: AdaptiveNSState) -> bool:
             dlogz = jnp.logaddexp(0, state.integrator.logZ_live - state.integrator.logZ)
             return bool(jnp.isfinite(dlogz) and dlogz < config.termination_dlogz)
@@ -223,9 +271,9 @@ class BlackJAXNSSSampler(Sampler):
             ):
                 _last_ckpt_t = config.write_checkpoint(
                     {
-                        "state": state,
-                        "dead": dead,
-                        "rng_key": rng_key,
+                        "state": jax.device_get(state),
+                        "dead": jax.device_get(dead),
+                        "rng_key": jax.device_get(rng_key),
                         "n_iter": n_iter,
                         "elapsed_time": self._prev_elapsed
                         + (time.perf_counter() - _method_t0),
@@ -233,7 +281,8 @@ class BlackJAXNSSSampler(Sampler):
                     self._checkpoint_tag,
                 )
 
-        self._final_state = finalise(state, dead)  # type: ignore[arg-type]  # AdaptiveNSState structurally satisfies NSState (.particles field)
+        final_state = finalise(state, dead)  # type: ignore[arg-type]  # AdaptiveNSState structurally satisfies NSState (.particles field)
+        self._final_state = jax.device_get(final_state)
         self._n_iterations = n_iter
 
         # Build anesthetic NestedSamples for use in get_samples() and get_diagnostics().

--- a/src/jimgw/samplers/blackjax/nss.py
+++ b/src/jimgw/samplers/blackjax/nss.py
@@ -215,6 +215,7 @@ class BlackJAXNSSSampler(Sampler):
             and config.checkpoint_interval > 0
             and ckpt_path.exists()
         ):
+            _initial_rng_key = rng_key
             try:
                 with open(ckpt_path, "rb") as _f:
                     _ckpt = pickle.load(_f)
@@ -247,6 +248,7 @@ class BlackJAXNSSSampler(Sampler):
                     ckpt_path,
                     _e,
                 )
+                rng_key = _initial_rng_key
                 state = _batched_nss_init(
                     _validated_initial_particles(initial_position)
                 )

--- a/src/jimgw/samplers/blackjax/sharding.py
+++ b/src/jimgw/samplers/blackjax/sharding.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Optional
 
 import jax
 import jax.numpy as jnp
@@ -13,7 +13,7 @@ from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
 _LIVE_AXIS = "live"
 
 
-def make_live_mesh(n_devices: int, n_live: int, n_delete: int) -> Mesh | None:
+def make_live_mesh(n_devices: int, n_live: int, n_delete: int) -> Optional[Mesh]:
     """Build a single-host device mesh for the live-particle axis."""
     if n_devices == 1:
         return None

--- a/src/jimgw/samplers/blackjax/sharding.py
+++ b/src/jimgw/samplers/blackjax/sharding.py
@@ -1,0 +1,177 @@
+"""Multi-device strategies for BlackJAX nested sampling."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from blackjax.ns.adaptive import build_kernel as build_adaptive_kernel
+from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
+
+_LIVE_AXIS = "live"
+
+
+def make_live_mesh(n_devices: int, n_live: int, n_delete: int) -> Mesh | None:
+    """Build a single-host device mesh for the live-particle axis."""
+    if n_devices == 1:
+        return None
+
+    devices = jax.local_devices()
+    if n_devices > len(devices):
+        raise ValueError(
+            f"n_devices={n_devices} requested, but only {len(devices)} local "
+            "JAX devices are available."
+        )
+    if n_live % n_devices:
+        raise ValueError(f"n_live={n_live} must be divisible by n_devices={n_devices}.")
+    if n_delete % n_devices:
+        raise ValueError(
+            f"n_delete={n_delete} must be divisible by n_devices={n_devices}."
+        )
+
+    return Mesh(np.asarray(devices[:n_devices]), axis_names=(_LIVE_AXIS,))
+
+
+def place_state(state, mesh: Mesh):
+    """Shard live particles and replicate adaptive/integrator state."""
+    live = NamedSharding(mesh, P(_LIVE_AXIS))
+    replicated = NamedSharding(mesh, P())
+    return state._replace(
+        particles=jax.tree.map(lambda x: jax.device_put(x, live), state.particles),
+        inner_kernel_params=jax.tree.map(
+            lambda x: jax.device_put(x, replicated), state.inner_kernel_params
+        ),
+        integrator=jax.tree.map(
+            lambda x: jax.device_put(x, replicated), state.integrator
+        ),
+    )
+
+
+def place_key(rng_key, mesh: Mesh):
+    """Replicate a sampler PRNG key over the mesh."""
+    return jax.device_put(rng_key, NamedSharding(mesh, P()))
+
+
+def _all_gather(mesh: Mesh, value, in_spec):
+    def gather(x):
+        return jax.lax.all_gather(x, _LIVE_AXIS, tiled=True)
+
+    return jax.shard_map(
+        gather,
+        mesh=mesh,
+        in_specs=in_spec,
+        out_specs=P(),
+        check_vma=False,
+    )(value)
+
+
+def delete_fn_sharded(mesh: Mesh, n_delete: int) -> Callable:
+    """Select the globally lowest-likelihood live particles."""
+
+    def delete_fn(state):
+        global_log_likelihood = _all_gather(
+            mesh, state.particles.loglikelihood, P(_LIVE_AXIS)
+        )
+        _, dead_idx = jax.lax.top_k(-global_log_likelihood, n_delete)
+        return dead_idx, dead_idx
+
+    return delete_fn
+
+
+def update_with_mcmc_take_last_sharded(
+    constrained_step_fn: Callable,
+    n_inner_steps: int,
+    n_delete: int,
+    mesh: Mesh,
+) -> Callable:
+    """Run independent constrained replacement chains across the mesh."""
+    live = NamedSharding(mesh, P(_LIVE_AXIS))
+
+    def update_function(rng_key, state, loglikelihood_0, **step_parameters):
+        particles = state.particles
+        particle_specs = jax.tree.map(
+            lambda x: P(_LIVE_AXIS) if x.ndim > 0 else P(), particles
+        )
+        global_particles = jax.shard_map(
+            lambda xs: jax.tree.map(
+                lambda x: jax.lax.all_gather(x, _LIVE_AXIS, tiled=True), xs
+            ),
+            mesh=mesh,
+            in_specs=(particle_specs,),
+            out_specs=jax.tree.map(lambda _: P(), particles),
+            check_vma=False,
+        )(particles)
+        global_log_likelihood = global_particles.loglikelihood
+
+        survivor_weights = (global_log_likelihood > loglikelihood_0).astype(jnp.float32)
+        survivor_weights = jnp.where(
+            survivor_weights.sum() > 0,
+            survivor_weights,
+            jnp.ones_like(survivor_weights),
+        )
+
+        choice_key, sample_key = jax.random.split(rng_key)
+        start_idx = jax.random.choice(
+            choice_key,
+            global_log_likelihood.shape[0],
+            shape=(n_delete,),
+            p=survivor_weights / survivor_weights.sum(),
+            replace=True,
+        )
+        start_states = jax.tree.map(lambda x: x[start_idx], global_particles)
+        start_states = jax.tree.map(lambda x: jax.device_put(x, live), start_states)
+        sample_keys = jax.device_put(jax.random.split(sample_key, n_delete), live)
+
+        state_specs = jax.tree.map(
+            lambda x: P(_LIVE_AXIS) if x.ndim > 0 else P(), start_states
+        )
+        parameter_specs = jax.tree.map(lambda _: P(), step_parameters)
+
+        def run_local_chains(keys, states, threshold, parameters):
+            def run_chain(key, chain_state):
+                keys = jax.random.split(key, n_inner_steps)
+
+                def body_fn(current_state, step_key):
+                    return constrained_step_fn(
+                        step_key,
+                        current_state,
+                        threshold,
+                        **parameters,
+                    )
+
+                return jax.lax.scan(body_fn, chain_state, keys)
+
+            return jax.vmap(run_chain)(keys, states)
+
+        return jax.shard_map(
+            run_local_chains,
+            mesh=mesh,
+            in_specs=(P(_LIVE_AXIS), state_specs, P(), parameter_specs),
+            out_specs=(state_specs, P(_LIVE_AXIS)),
+            check_vma=False,
+        )(sample_keys, start_states, loglikelihood_0, step_parameters)
+
+    return update_function
+
+
+def build_sharded_from_mcmc_kernel(
+    constrained_step_fn: Callable,
+    n_inner_steps: int,
+    update_inner_kernel_params_fn: Callable,
+    n_delete: int,
+    mesh: Mesh,
+) -> Callable:
+    """Assemble BlackJAX's adaptive NS kernel with sharded strategies."""
+    inner_kernel = update_with_mcmc_take_last_sharded(
+        constrained_step_fn,
+        n_inner_steps=n_inner_steps,
+        n_delete=n_delete,
+        mesh=mesh,
+    )
+    return build_adaptive_kernel(
+        delete_fn_sharded(mesh, n_delete),
+        inner_kernel,
+        update_inner_kernel_params_fn=update_inner_kernel_params_fn,
+    )

--- a/src/jimgw/samplers/blackjax/smc.py
+++ b/src/jimgw/samplers/blackjax/smc.py
@@ -201,6 +201,7 @@ class BlackJAXSMCSampler(Sampler):
             and config.checkpoint_interval > 0
             and ckpt_path.exists()
         ):
+            _initial_rng_key = rng_key
             try:
                 with open(ckpt_path, "rb") as _f:
                     _ckpt = pickle.load(
@@ -234,6 +235,7 @@ class BlackJAXSMCSampler(Sampler):
                     ckpt_path,
                     _e,
                 )
+                rng_key = _initial_rng_key
                 state = smc_alg.init(initial_particles)  # type: ignore[call-arg]  # blackjax API
                 self._prev_elapsed = 0.0
         else:
@@ -334,6 +336,7 @@ class BlackJAXSMCSampler(Sampler):
             and config.checkpoint_interval > 0
             and ckpt_path.exists()
         ):
+            _initial_rng_key = rng_key
             try:
                 with open(ckpt_path, "rb") as _f:
                     _ckpt = pickle.load(_f)
@@ -349,6 +352,7 @@ class BlackJAXSMCSampler(Sampler):
                         n_iter,
                         n_schedule,
                     )
+                    rng_key = _initial_rng_key
                     state = smc_alg.init(initial_particles)  # type: ignore[call-arg]  # blackjax API
                     n_iter = 0
                     accept_list = []
@@ -375,6 +379,7 @@ class BlackJAXSMCSampler(Sampler):
                     ckpt_path,
                     _e,
                 )
+                rng_key = _initial_rng_key
                 state = smc_alg.init(initial_particles)  # type: ignore[call-arg]  # blackjax API
                 self._prev_elapsed = 0.0
         else:
@@ -460,6 +465,7 @@ class BlackJAXSMCSampler(Sampler):
             and config.checkpoint_interval > 0
             and ckpt_path.exists()
         ):
+            _initial_rng_key = rng_key
             try:
                 with open(ckpt_path, "rb") as _f:
                     _ckpt = pickle.load(_f)
@@ -491,6 +497,7 @@ class BlackJAXSMCSampler(Sampler):
                     ckpt_path,
                     _e,
                 )
+                rng_key = _initial_rng_key
                 state = smc_alg.init(initial_particles)  # type: ignore[call-arg]  # blackjax API
                 self._prev_elapsed = 0.0
         else:
@@ -584,6 +591,7 @@ class BlackJAXSMCSampler(Sampler):
             and config.checkpoint_interval > 0
             and ckpt_path.exists()
         ):
+            _initial_rng_key = rng_key
             try:
                 with open(ckpt_path, "rb") as _f:
                     _ckpt = pickle.load(_f)
@@ -600,6 +608,7 @@ class BlackJAXSMCSampler(Sampler):
                         n_iter,
                         n_schedule,
                     )
+                    rng_key = _initial_rng_key
                     state = smc_alg.init(initial_particles)  # type: ignore[call-arg]  # blackjax API
                     n_iter = 0
                     accept_list = []
@@ -627,6 +636,7 @@ class BlackJAXSMCSampler(Sampler):
                     ckpt_path,
                     _e,
                 )
+                rng_key = _initial_rng_key
                 state = smc_alg.init(initial_particles)  # type: ignore[call-arg]  # blackjax API
                 self._prev_elapsed = 0.0
         else:

--- a/src/jimgw/samplers/blackjax/smc.py
+++ b/src/jimgw/samplers/blackjax/smc.py
@@ -14,6 +14,7 @@ import pickle
 import shutil
 import time
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any, Optional
 
 import jax
@@ -152,6 +153,94 @@ class BlackJAXSMCSampler(Sampler):
 
         return step
 
+    def _resume_or_init_state(
+        self,
+        ckpt_path: Optional[Path],
+        config: BlackJAXSMCConfig,
+        rng_key: Key,
+        initial_particles,
+        smc_alg,
+        fresh_extra: dict[str, Any],
+        restore_extra: Callable[[dict], dict[str, Any]],
+        n_schedule: Optional[int] = None,
+    ) -> tuple[Any, Key, int, dict[str, Any]]:
+        """Resume ``(state, rng_key, n_iter, extra)`` from a checkpoint, or init fresh.
+
+        ``restore_extra`` maps a loaded checkpoint dict to the mode-specific
+        history fields (e.g. acceptance/covariance/tempering history);
+        ``fresh_extra`` is used whenever sampling starts fresh — no
+        checkpoint, an incompatible/corrupt one, or (fixed-ladder modes
+        only, via ``n_schedule``) a checkpoint whose ``n_iter`` exceeds the
+        current schedule length. Sets ``self._prev_elapsed`` as a side
+        effect, matching each mode's previous per-branch behavior.
+        """
+        if not (
+            ckpt_path is not None
+            and config.checkpoint_interval > 0
+            and ckpt_path.exists()
+        ):
+            self._prev_elapsed = 0.0
+            return (
+                smc_alg.init(initial_particles),  # type: ignore[call-arg]  # blackjax API
+                rng_key,
+                0,
+                dict(fresh_extra),
+            )
+
+        _initial_rng_key = rng_key
+        try:
+            with open(ckpt_path, "rb") as _f:
+                _ckpt = pickle.load(
+                    _f
+                )  # Only load trusted checkpoints — pickle executes arbitrary code.
+            self._validate_checkpoint(_ckpt)
+            state = _ckpt["state"]
+            rng_key = _ckpt["rng_key"]
+            n_iter = _ckpt["n_iter"]
+            extra = restore_extra(_ckpt)
+            if n_schedule is not None and n_iter > n_schedule:
+                logger.warning(
+                    "%s: checkpoint n_iter=%d exceeds current schedule length=%d — starting fresh.",
+                    f"{self.sampler_name} ({self.mode.upper()})",
+                    n_iter,
+                    n_schedule,
+                )
+                rng_key = _initial_rng_key
+                state = smc_alg.init(initial_particles)  # type: ignore[call-arg]  # blackjax API
+                n_iter = 0
+                extra = dict(fresh_extra)
+                self._prev_elapsed = 0.0
+            else:
+                self._prev_elapsed = float(_ckpt["elapsed_time"])
+                logger.info(
+                    "%s: resumed from checkpoint at n_iter=%d (%s)",
+                    f"{self.sampler_name} ({self.mode.upper()})",
+                    n_iter,
+                    ckpt_path,
+                )
+            return state, rng_key, n_iter, extra
+        except (
+            OSError,
+            EOFError,
+            KeyError,
+            TypeError,
+            ValueError,
+            pickle.UnpicklingError,
+        ) as _e:
+            logger.warning(
+                "%s: incompatible or corrupt checkpoint at %s (%s) — starting fresh.",
+                f"{self.sampler_name} ({self.mode.upper()})",
+                ckpt_path,
+                _e,
+            )
+            self._prev_elapsed = 0.0
+            return (
+                smc_alg.init(initial_particles),  # type: ignore[call-arg]  # blackjax API
+                _initial_rng_key,
+                0,
+                dict(fresh_extra),
+            )
+
     # ------------------------------------------------------------------
     # Mode runners
     # ------------------------------------------------------------------
@@ -190,56 +279,27 @@ class BlackJAXSMCSampler(Sampler):
             batch_size=config.batch_size,
         )
 
-        accept_list: list[float] = []
-        cov_scale_list: list[float] = []
         cov_scale = float(config.initial_cov_scale)
-        n_iter = 0
-
-        # Resume from checkpoint if one exists.
-        if (
-            ckpt_path is not None
-            and config.checkpoint_interval > 0
-            and ckpt_path.exists()
-        ):
-            _initial_rng_key = rng_key
-            try:
-                with open(ckpt_path, "rb") as _f:
-                    _ckpt = pickle.load(
-                        _f
-                    )  # Only load trusted checkpoints — pickle executes arbitrary code.
-                self._validate_checkpoint(_ckpt)
-                state = _ckpt["state"]
-                rng_key = _ckpt["rng_key"]
-                n_iter = _ckpt["n_iter"]
-                cov_scale = float(_ckpt.get("cov_scale", cov_scale))
-                accept_list = list(_ckpt["accept_history"])
-                cov_scale_list = list(_ckpt["cov_scale_history"])
-                self._prev_elapsed = float(_ckpt["elapsed_time"])
-                logger.info(
-                    "%s: resumed from checkpoint at n_iter=%d (%s)",
-                    f"{self.sampler_name} ({self.mode.upper()})",
-                    n_iter,
-                    ckpt_path,
-                )
-            except (
-                OSError,
-                EOFError,
-                KeyError,
-                TypeError,
-                ValueError,
-                pickle.UnpicklingError,
-            ) as _e:
-                logger.warning(
-                    "%s: incompatible or corrupt checkpoint at %s (%s) — starting fresh.",
-                    f"{self.sampler_name} ({self.mode.upper()})",
-                    ckpt_path,
-                    _e,
-                )
-                rng_key = _initial_rng_key
-                state = smc_alg.init(initial_particles)  # type: ignore[call-arg]  # blackjax API
-                self._prev_elapsed = 0.0
-        else:
-            state = smc_alg.init(initial_particles)  # type: ignore[call-arg]  # blackjax API
+        state, rng_key, n_iter, _extra = self._resume_or_init_state(
+            ckpt_path,
+            config,
+            rng_key,
+            initial_particles,
+            smc_alg,
+            fresh_extra={
+                "cov_scale": cov_scale,
+                "accept_history": [],
+                "cov_scale_history": [],
+            },
+            restore_extra=lambda ckpt: {
+                "cov_scale": float(ckpt.get("cov_scale", cov_scale)),
+                "accept_history": list(ckpt["accept_history"]),
+                "cov_scale_history": list(ckpt["cov_scale_history"]),
+            },
+        )
+        cov_scale = _extra["cov_scale"]
+        accept_list: list[float] = _extra["accept_history"]
+        cov_scale_list: list[float] = _extra["cov_scale_history"]
 
         step_fn = jax.jit(smc_alg.step)
         _last_ckpt_t = time.perf_counter()
@@ -327,63 +387,17 @@ class BlackJAXSMCSampler(Sampler):
             batch_size=config.batch_size,
         )
 
-        accept_list: list[float] = []
-        n_iter = 0
-
-        # Resume from checkpoint if one exists.
-        if (
-            ckpt_path is not None
-            and config.checkpoint_interval > 0
-            and ckpt_path.exists()
-        ):
-            _initial_rng_key = rng_key
-            try:
-                with open(ckpt_path, "rb") as _f:
-                    _ckpt = pickle.load(_f)
-                self._validate_checkpoint(_ckpt)
-                state = _ckpt["state"]
-                rng_key = _ckpt["rng_key"]
-                n_iter = _ckpt["n_iter"]
-                accept_list = list(_ckpt["accept_history"])
-                if n_iter > n_schedule:
-                    logger.warning(
-                        "%s: checkpoint n_iter=%d exceeds current schedule length=%d — starting fresh.",
-                        f"{self.sampler_name} ({self.mode.upper()})",
-                        n_iter,
-                        n_schedule,
-                    )
-                    rng_key = _initial_rng_key
-                    state = smc_alg.init(initial_particles)  # type: ignore[call-arg]  # blackjax API
-                    n_iter = 0
-                    accept_list = []
-                    self._prev_elapsed = 0.0
-                else:
-                    self._prev_elapsed = float(_ckpt["elapsed_time"])
-                    logger.info(
-                        "%s: resumed from checkpoint at n_iter=%d (%s)",
-                        f"{self.sampler_name} ({self.mode.upper()})",
-                        n_iter,
-                        ckpt_path,
-                    )
-            except (
-                OSError,
-                EOFError,
-                KeyError,
-                TypeError,
-                ValueError,
-                pickle.UnpicklingError,
-            ) as _e:
-                logger.warning(
-                    "%s: incompatible or corrupt checkpoint at %s (%s) — starting fresh.",
-                    f"{self.sampler_name} ({self.mode.upper()})",
-                    ckpt_path,
-                    _e,
-                )
-                rng_key = _initial_rng_key
-                state = smc_alg.init(initial_particles)  # type: ignore[call-arg]  # blackjax API
-                self._prev_elapsed = 0.0
-        else:
-            state = smc_alg.init(initial_particles)  # type: ignore[call-arg]  # blackjax API
+        state, rng_key, n_iter, _extra = self._resume_or_init_state(
+            ckpt_path,
+            config,
+            rng_key,
+            initial_particles,
+            smc_alg,
+            fresh_extra={"accept_history": []},
+            restore_extra=lambda ckpt: {"accept_history": list(ckpt["accept_history"])},
+            n_schedule=n_schedule,
+        )
+        accept_list: list[float] = _extra["accept_history"]
 
         step_fn = jax.jit(smc_alg.step)
         _last_ckpt_t = time.perf_counter()
@@ -454,54 +468,26 @@ class BlackJAXSMCSampler(Sampler):
             batch_size=config.batch_size,
         )
 
-        accept_list: list[float] = []
-        temp_list: list[float] = []
-        is_weights_list: list[np.ndarray] = []
-        n_iter = 0
-
-        # Resume from checkpoint if one exists.
-        if (
-            ckpt_path is not None
-            and config.checkpoint_interval > 0
-            and ckpt_path.exists()
-        ):
-            _initial_rng_key = rng_key
-            try:
-                with open(ckpt_path, "rb") as _f:
-                    _ckpt = pickle.load(_f)
-                self._validate_checkpoint(_ckpt)
-                state = _ckpt["state"]
-                rng_key = _ckpt["rng_key"]
-                n_iter = _ckpt["n_iter"]
-                accept_list = list(_ckpt["accept_history"])
-                temp_list = list(_ckpt["tempering_schedule"])
-                is_weights_list = list(_ckpt["is_weights_history"])
-                self._prev_elapsed = float(_ckpt["elapsed_time"])
-                logger.info(
-                    "%s: resumed from checkpoint at n_iter=%d (%s)",
-                    f"{self.sampler_name} ({self.mode.upper()})",
-                    n_iter,
-                    ckpt_path,
-                )
-            except (
-                OSError,
-                EOFError,
-                KeyError,
-                TypeError,
-                ValueError,
-                pickle.UnpicklingError,
-            ) as _e:
-                logger.warning(
-                    "%s: incompatible or corrupt checkpoint at %s (%s) — starting fresh.",
-                    f"{self.sampler_name} ({self.mode.upper()})",
-                    ckpt_path,
-                    _e,
-                )
-                rng_key = _initial_rng_key
-                state = smc_alg.init(initial_particles)  # type: ignore[call-arg]  # blackjax API
-                self._prev_elapsed = 0.0
-        else:
-            state = smc_alg.init(initial_particles)  # type: ignore[call-arg]  # blackjax API
+        state, rng_key, n_iter, _extra = self._resume_or_init_state(
+            ckpt_path,
+            config,
+            rng_key,
+            initial_particles,
+            smc_alg,
+            fresh_extra={
+                "accept_history": [],
+                "tempering_schedule": [],
+                "is_weights_history": [],
+            },
+            restore_extra=lambda ckpt: {
+                "accept_history": list(ckpt["accept_history"]),
+                "tempering_schedule": list(ckpt["tempering_schedule"]),
+                "is_weights_history": list(ckpt["is_weights_history"]),
+            },
+        )
+        accept_list: list[float] = _extra["accept_history"]
+        temp_list: list[float] = _extra["tempering_schedule"]
+        is_weights_list: list[np.ndarray] = _extra["is_weights_history"]
 
         step_fn = jax.jit(smc_alg.step)
         _last_ckpt_t = time.perf_counter()
@@ -581,66 +567,21 @@ class BlackJAXSMCSampler(Sampler):
             batch_size=config.batch_size,
         )
 
-        accept_list: list[float] = []
-        is_weights_list: list[np.ndarray] = []
-        n_iter = 0
-
-        # Resume from checkpoint if one exists.
-        if (
-            ckpt_path is not None
-            and config.checkpoint_interval > 0
-            and ckpt_path.exists()
-        ):
-            _initial_rng_key = rng_key
-            try:
-                with open(ckpt_path, "rb") as _f:
-                    _ckpt = pickle.load(_f)
-                self._validate_checkpoint(_ckpt)
-                state = _ckpt["state"]
-                rng_key = _ckpt["rng_key"]
-                n_iter = _ckpt["n_iter"]
-                accept_list = list(_ckpt["accept_history"])
-                is_weights_list = list(_ckpt["is_weights_history"])
-                if n_iter > n_schedule:
-                    logger.warning(
-                        "%s: checkpoint n_iter=%d exceeds current schedule length=%d — starting fresh.",
-                        f"{self.sampler_name} ({self.mode.upper()})",
-                        n_iter,
-                        n_schedule,
-                    )
-                    rng_key = _initial_rng_key
-                    state = smc_alg.init(initial_particles)  # type: ignore[call-arg]  # blackjax API
-                    n_iter = 0
-                    accept_list = []
-                    is_weights_list = []
-                    self._prev_elapsed = 0.0
-                else:
-                    self._prev_elapsed = float(_ckpt["elapsed_time"])
-                    logger.info(
-                        "%s: resumed from checkpoint at n_iter=%d (%s)",
-                        f"{self.sampler_name} ({self.mode.upper()})",
-                        n_iter,
-                        ckpt_path,
-                    )
-            except (
-                OSError,
-                EOFError,
-                KeyError,
-                TypeError,
-                ValueError,
-                pickle.UnpicklingError,
-            ) as _e:
-                logger.warning(
-                    "%s: incompatible or corrupt checkpoint at %s (%s) — starting fresh.",
-                    f"{self.sampler_name} ({self.mode.upper()})",
-                    ckpt_path,
-                    _e,
-                )
-                rng_key = _initial_rng_key
-                state = smc_alg.init(initial_particles)  # type: ignore[call-arg]  # blackjax API
-                self._prev_elapsed = 0.0
-        else:
-            state = smc_alg.init(initial_particles)  # type: ignore[call-arg]  # blackjax API
+        state, rng_key, n_iter, _extra = self._resume_or_init_state(
+            ckpt_path,
+            config,
+            rng_key,
+            initial_particles,
+            smc_alg,
+            fresh_extra={"accept_history": [], "is_weights_history": []},
+            restore_extra=lambda ckpt: {
+                "accept_history": list(ckpt["accept_history"]),
+                "is_weights_history": list(ckpt["is_weights_history"]),
+            },
+            n_schedule=n_schedule,
+        )
+        accept_list: list[float] = _extra["accept_history"]
+        is_weights_list: list[np.ndarray] = _extra["is_weights_history"]
 
         step_fn = jax.jit(smc_alg.step)
         _last_ckpt_t = time.perf_counter()

--- a/src/jimgw/samplers/blackjax/swig.py
+++ b/src/jimgw/samplers/blackjax/swig.py
@@ -8,14 +8,13 @@ from typing import NamedTuple, Optional
 import jax
 import jax.numpy as jnp
 from blackjax import SamplingAlgorithm
-from blackjax.base import Position, State
 from blackjax.mcmc.slice import SliceInfo
 from blackjax.mcmc.slice import build_kernel as build_slice_kernel
 from blackjax.mcmc.slice import stepping_out
 from blackjax.ns.from_mcmc import build_kernel as build_from_mcmc_kernel
 from blackjax.ns.nss import sample_direction_from_covariance
 from blackjax.smc.tuning.from_particles import particles_covariance_matrix
-from blackjax.types import PRNGKey
+from jax.sharding import Mesh
 from jaxtyping import Array, Float
 
 from jimgw.samplers.blackjax.nss import BlackJAXNSSSampler
@@ -239,7 +238,9 @@ class BlackJAXSwiGSampler(BlackJAXNSSSampler):
     def _update_inner_kernel_params_fn(self) -> Callable:
         return self._update_block_covariances
 
-    def _build_nested_sampler(self, n_delete: int, mesh=None) -> SamplingAlgorithm:
+    def _build_nested_sampler(
+        self, n_delete: int, mesh: Optional[Mesh] = None
+    ) -> SamplingAlgorithm:
         constrained_step = _build_swig_constrained_step(
             log_prior_fn=self._log_prior_fn,
             build_cache=self._build_cache,
@@ -268,10 +269,10 @@ class BlackJAXSwiGSampler(BlackJAXNSSSampler):
                 mesh=mesh,
             )
 
-        def initialize(position: Position, rng_key: Optional[PRNGKey]) -> State:
-            del rng_key
-            # ``build_from_mcmc_kernel`` initializes directly from a position,
-            # although BlackJAX types every initializer as returning a state.
-            return position  # type: ignore[return-value]
-
-        return SamplingAlgorithm(initialize, kernel)
+        # `nested_sampler.init` is never called (state init happens in
+        # `_batched_nss_init`); BlackJAX still requires SamplingAlgorithm.init
+        # to type as returning a State.
+        return SamplingAlgorithm(
+            lambda position, rng_key=None: position,  # type: ignore[return-value]
+            kernel,
+        )

--- a/src/jimgw/samplers/blackjax/swig.py
+++ b/src/jimgw/samplers/blackjax/swig.py
@@ -15,6 +15,7 @@ from blackjax.ns.nss import sample_direction_from_covariance
 from blackjax.smc.tuning.from_particles import particles_covariance_matrix
 
 from jimgw.samplers.blackjax.nss import BlackJAXNSSSampler
+from jimgw.samplers.blackjax.sharding import build_sharded_from_mcmc_kernel
 from jimgw.samplers.config import BlackJAXSwiGConfig
 from jimgw.samplers.periodic import _build_masks_arrays
 
@@ -214,7 +215,7 @@ class BlackJAXSwiGSampler(BlackJAXNSSSampler):
     def _update_inner_kernel_params_fn(self) -> Callable:
         return self._block_covariance_update
 
-    def _build_nested_sampler(self, n_delete: int) -> SamplingAlgorithm:
+    def _build_nested_sampler(self, n_delete: int, mesh=None) -> SamplingAlgorithm:
         constrained_step = _build_swig_constrained_step(
             log_prior_fn=self._log_prior_fn,
             build_cache_fn=self._build_cache_fn,
@@ -228,10 +229,19 @@ class BlackJAXSwiGSampler(BlackJAXNSSSampler):
             periodic=self._periodic,
             n_dims=self.n_dims,
         )
-        kernel = build_from_mcmc_kernel(
-            constrained_step,
-            num_inner_steps=1,
-            update_inner_kernel_params_fn=self._block_covariance_update,
-            num_delete=n_delete,
-        )
+        if mesh is None:
+            kernel = build_from_mcmc_kernel(
+                constrained_step,
+                num_inner_steps=1,
+                update_inner_kernel_params_fn=self._block_covariance_update,
+                num_delete=n_delete,
+            )
+        else:
+            kernel = build_sharded_from_mcmc_kernel(
+                constrained_step,
+                n_inner_steps=1,
+                update_inner_kernel_params_fn=self._block_covariance_update,
+                n_delete=n_delete,
+                mesh=mesh,
+            )
         return SamplingAlgorithm(lambda position, rng_key=None: position, kernel)

--- a/src/jimgw/samplers/config.py
+++ b/src/jimgw/samplers/config.py
@@ -117,6 +117,19 @@ class _CheckpointMixin(BaseModel):
         jax.config.update("jax_persistent_cache_min_compile_time_secs", 0.0)
 
 
+class _ShardingMixin(BaseModel):
+    """Single-host device sharding shared by BlackJAX nested samplers."""
+
+    n_devices: int = 1
+
+    @field_validator("n_devices")
+    @classmethod
+    def _positive_n_devices(cls, value: int) -> int:
+        if value < 1:
+            raise ValueError("n_devices must be >= 1")
+        return value
+
+
 # ---------------------------------------------------------------------------
 # flowMC sub-configs
 # ---------------------------------------------------------------------------
@@ -316,7 +329,7 @@ class BlackJAXNSAWConfig(BaseSamplerConfig, _CheckpointMixin):
         return self
 
 
-class BlackJAXNSSConfig(BaseSamplerConfig, _CheckpointMixin):
+class BlackJAXNSSConfig(BaseSamplerConfig, _CheckpointMixin, _ShardingMixin):
     """Configuration for the BlackJAX nested slice sampler.
 
     !!! note
@@ -349,10 +362,14 @@ class BlackJAXNSSConfig(BaseSamplerConfig, _CheckpointMixin):
                 f"yields n_delete = {n_delete}; require n_delete >= 1. "
                 "Increase n_live or n_delete_frac."
             )
+        if self.n_devices > 1 and self.n_live % self.n_devices:
+            raise ValueError("n_live must be divisible by n_devices when sharding")
+        if self.n_devices > 1 and n_delete % self.n_devices:
+            raise ValueError("n_delete must be divisible by n_devices when sharding")
         return self
 
 
-class BlackJAXSwiGConfig(BaseSamplerConfig, _CheckpointMixin):
+class BlackJAXSwiGConfig(BaseSamplerConfig, _CheckpointMixin, _ShardingMixin):
     """Configuration for Nested Slice within Gibbs (SwiG) sampling.
 
     ``blocks`` are expressed in Jim's sampling-space parameter names. Jim
@@ -414,6 +431,10 @@ class BlackJAXSwiGConfig(BaseSamplerConfig, _CheckpointMixin):
                 f"n_live * n_delete_frac = {self.n_live * self.n_delete_frac} "
                 f"yields n_delete = {n_delete}; require n_delete >= 1."
             )
+        if self.n_devices > 1 and self.n_live % self.n_devices:
+            raise ValueError("n_live must be divisible by n_devices when sharding")
+        if self.n_devices > 1 and n_delete % self.n_devices:
+            raise ValueError("n_delete must be divisible by n_devices when sharding")
         return self
 
 

--- a/tests/integration/test_sampler_sharding.py
+++ b/tests/integration/test_sampler_sharding.py
@@ -1,0 +1,82 @@
+"""Integration test: sharded BlackJAX NSS/SwiG sampling through the full Jim pipeline.
+
+Requires 4 local JAX devices — run with
+``XLA_FLAGS=--xla_force_host_platform_device_count=4 pytest ...``. Unlike
+``tests/unit/samplers/blackjax/test_sharding.py`` (which drives
+``BlackJAXNSSSampler``/``BlackJAXSwiGSampler`` directly), these tests exercise
+sharding through ``Jim`` end-to-end: config parsing, prior/likelihood wiring,
+and the checkpoint-free sampling loop are all included.
+"""
+
+from __future__ import annotations
+
+import math
+
+import jax
+import numpy as np
+import pytest
+
+_HAS_FOUR_DEVICES = jax.local_device_count() >= 4
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _HAS_FOUR_DEVICES,
+        reason="run with XLA_FLAGS=--xla_force_host_platform_device_count=4",
+    ),
+]
+
+blackjax = pytest.importorskip("blackjax")
+
+from jimgw.samplers.config import BlackJAXNSSConfig, BlackJAXSwiGConfig  # noqa: E402
+
+from tests.integration._helpers import (  # noqa: E402
+    make_gaussian_jim,
+    make_gaussian_swig_jim,
+)
+
+
+@pytest.fixture(scope="module")
+def sharded_nss_jim():
+    cfg = BlackJAXNSSConfig(
+        n_live=48, n_delete_frac=0.25, termination_dlogz=0.5, n_devices=4
+    )
+    jim = make_gaussian_jim(cfg)
+    jim.sample()
+    return jim
+
+
+def test_sharded_nss_posterior_mean_near_half(sharded_nss_jim):
+    samples = sharded_nss_jim.get_samples()
+    assert abs(float(np.mean(samples["x"])) - 0.5) < 0.15
+    assert abs(float(np.mean(samples["y"])) - 0.5) < 0.15
+
+
+def test_sharded_nss_log_evidence_finite(sharded_nss_jim):
+    diag = sharded_nss_jim.sampler.get_diagnostics()
+    assert math.isfinite(diag["log_Z"])
+
+
+@pytest.fixture(scope="module")
+def sharded_swig_jim():
+    cfg = BlackJAXSwiGConfig(
+        blocks=[["x"], ["y"]],
+        n_live=48,
+        n_delete_frac=0.25,
+        termination_dlogz=0.5,
+        n_devices=4,
+    )
+    jim = make_gaussian_swig_jim(cfg)
+    jim.sample()
+    return jim
+
+
+def test_sharded_swig_posterior_mean_near_half(sharded_swig_jim):
+    samples = sharded_swig_jim.get_samples()
+    assert abs(float(np.mean(samples["x"])) - 0.5) < 0.15
+    assert abs(float(np.mean(samples["y"])) - 0.5) < 0.15
+
+
+def test_sharded_swig_log_evidence_finite(sharded_swig_jim):
+    diag = sharded_swig_jim.sampler.get_diagnostics()
+    assert np.isfinite(diag["log_Z"])

--- a/tests/unit/samplers/blackjax/test_ns_aw.py
+++ b/tests/unit/samplers/blackjax/test_ns_aw.py
@@ -332,4 +332,74 @@ def test_ns_aw_resume_gives_same_result(tmp_path, monkeypatch):
     s_c.sample(jax.random.key(0), _init_pos(100))
 
     assert s_c.get_diagnostics()["log_Z"] == pytest.approx(log_z_a, rel=1e-6)
+
+
+def test_ns_aw_checkpoint_failure_restores_caller_rng_key(tmp_path):
+    """A checkpoint that fails *after* its rng_key is read falls back to the
+    caller-supplied key, not the partially-loaded checkpoint's key.
+    """
+    prior = CombinePrior(
+        [
+            UniformPrior(0.0, 1.0, parameter_names=["x"]),
+            UniformPrior(0.0, 1.0, parameter_names=["y"]),
+        ]
+    )
+    likelihood = _GaussianLikelihood()
+    parameter_names = prior.parameter_names
+
+    def _make(checkpoint_dir=None):
+        config = BlackJAXNSAWConfig(
+            n_live=100,
+            n_delete_frac=0.5,
+            n_target=10,
+            max_mcmc=500,
+            max_proposals=200,
+            termination_dlogz=0.5,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_interval=1e-9 if checkpoint_dir is not None else 0.0,
+        )
+
+        def log_prior_fn(arr):
+            return prior.log_prob(dict(zip(parameter_names, arr, strict=True)))
+
+        def log_likelihood_fn(arr):
+            return likelihood.evaluate(dict(zip(parameter_names, arr, strict=True)))
+
+        def log_posterior_fn(arr):
+            return log_prior_fn(arr) + log_likelihood_fn(arr)
+
+        return BlackJAXNSAWSampler(
+            n_dims=len(parameter_names),
+            log_prior_fn=log_prior_fn,
+            log_likelihood_fn=log_likelihood_fn,
+            log_posterior_fn=log_posterior_fn,
+            config=config,
+        )
+
+    caller_key = jax.random.key(7)
+
+    reference = _make(checkpoint_dir=None)
+    reference.sample(caller_key, _init_pos(100))
+    log_z_reference = reference.get_diagnostics()["log_Z"]
+
+    sampler = _make(checkpoint_dir=tmp_path)
+    ckpt_path = tmp_path / "checkpoint.pkl"
+    # Valid enough to pass `_validate_checkpoint` and overwrite `rng_key` with
+    # a decoy key, but missing "n_iter" so loading fails right after.
+    with open(ckpt_path, "wb") as f:
+        pickle.dump(
+            {
+                "sampler_name": sampler.sampler_name,
+                "state": None,
+                "dead": None,
+                "rng_key": jax.random.key(999),
+            },
+            f,
+        )
+
+    sampler.sample(caller_key, _init_pos(100))
+
+    assert sampler.get_diagnostics()["log_Z"] == pytest.approx(
+        log_z_reference, rel=1e-6
+    )
     assert not (tmp_path / "checkpoint.pkl").exists(), "Checkpoint was not cleaned up"

--- a/tests/unit/samplers/blackjax/test_nss.py
+++ b/tests/unit/samplers/blackjax/test_nss.py
@@ -245,6 +245,74 @@ def test_nss_falls_back_to_fresh_run_on_foreign_checkpoint(tmp_path):
     assert "samples" in result
 
 
+def test_nss_checkpoint_failure_restores_caller_rng_key(tmp_path):
+    """A checkpoint that fails *after* its rng_key is read falls back to the
+    caller-supplied key, not the partially-loaded checkpoint's key.
+    """
+    prior = CombinePrior(
+        [
+            UniformPrior(0.0, 1.0, parameter_names=["x"]),
+            UniformPrior(0.0, 1.0, parameter_names=["y"]),
+        ]
+    )
+    likelihood = _GaussianLikelihood()
+    parameter_names = prior.parameter_names
+
+    def _make(checkpoint_dir=None):
+        config = BlackJAXNSSConfig(
+            n_live=20,
+            n_delete_frac=0.5,
+            num_inner_steps_per_dim=5,
+            termination_dlogz=0.5,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_interval=1e-9 if checkpoint_dir is not None else 0.0,
+        )
+
+        def log_prior_fn(arr):
+            return prior.log_prob(dict(zip(parameter_names, arr, strict=True)))
+
+        def log_likelihood_fn(arr):
+            return likelihood.evaluate(dict(zip(parameter_names, arr, strict=True)))
+
+        def log_posterior_fn(arr):
+            return log_prior_fn(arr) + log_likelihood_fn(arr)
+
+        return BlackJAXNSSSampler(
+            n_dims=len(parameter_names),
+            log_prior_fn=log_prior_fn,
+            log_likelihood_fn=log_likelihood_fn,
+            log_posterior_fn=log_posterior_fn,
+            config=config,
+        )
+
+    caller_key = jax.random.key(7)
+
+    reference = _make(checkpoint_dir=None)
+    reference.sample(caller_key, _init_pos(20))
+    log_z_reference = reference.get_diagnostics()["log_Z"]
+
+    sampler = _make(checkpoint_dir=tmp_path)
+    ckpt_path = tmp_path / "checkpoint.pkl"
+    # Valid enough to pass `_validate_checkpoint` and overwrite `rng_key` with
+    # a decoy key, but missing "n_iter" so loading fails right after.
+    with open(ckpt_path, "wb") as f:
+        pickle.dump(
+            {
+                "sampler_name": sampler.sampler_name,
+                "state": None,
+                "dead": None,
+                "rng_key": jax.random.key(999),
+            },
+            f,
+        )
+
+    sampler.sample(caller_key, _init_pos(20))
+
+    assert sampler.get_diagnostics()["log_Z"] == pytest.approx(
+        log_z_reference, rel=1e-6
+    )
+
+
 def test_nss_resume_gives_same_result(tmp_path, monkeypatch):
     """A run resumed from a crashed checkpoint gives the same log_Z as an uninterrupted run."""
     prior = CombinePrior(

--- a/tests/unit/samplers/blackjax/test_sharding.py
+++ b/tests/unit/samplers/blackjax/test_sharding.py
@@ -39,6 +39,20 @@ def test_make_live_mesh_rejects_unavailable_devices():
         make_live_mesh(jax.local_device_count() + 1, 16, 4)
 
 
+def test_make_live_mesh_rejects_indivisible_n_live(monkeypatch):
+    # Fake enough devices to clear the availability check without needing
+    # real hardware, so the n_live divisibility check below it is reachable.
+    monkeypatch.setattr(jax, "local_devices", lambda: [object(), object()])
+    with pytest.raises(ValueError, match="n_live=11 must be divisible by n_devices=2"):
+        make_live_mesh(2, 11, 4)
+
+
+def test_make_live_mesh_rejects_indivisible_n_delete(monkeypatch):
+    monkeypatch.setattr(jax, "local_devices", lambda: [object(), object()])
+    with pytest.raises(ValueError, match="n_delete=3 must be divisible by n_devices=2"):
+        make_live_mesh(2, 12, 3)
+
+
 @pytest.mark.skipif(
     not _HAS_FOUR_DEVICES,
     reason="run with XLA_FLAGS=--xla_force_host_platform_device_count=4",

--- a/tests/unit/samplers/blackjax/test_sharding.py
+++ b/tests/unit/samplers/blackjax/test_sharding.py
@@ -1,0 +1,154 @@
+"""Multi-device tests for BlackJAX NSS and SwiG."""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from jimgw.samplers.blackjax.nss import BlackJAXNSSSampler
+from jimgw.samplers.blackjax.sharding import make_live_mesh
+from jimgw.samplers.blackjax.swig import BlackJAXSwiGSampler
+from jimgw.samplers.config import BlackJAXNSSConfig, BlackJAXSwiGConfig
+
+_HAS_FOUR_DEVICES = jax.local_device_count() >= 4
+
+
+def _log_prior(position):
+    return jnp.where(jnp.all((position >= 0.0) & (position <= 1.0)), 0.0, -jnp.inf)
+
+
+def _build_cache(position):
+    return position[0] ** 2
+
+
+def _log_likelihood_from_cache(position, cache):
+    return -20.0 * ((cache - 0.25) ** 2 + (position[1] - 0.5) ** 2)
+
+
+def _log_likelihood(position):
+    return _log_likelihood_from_cache(position, _build_cache(position))
+
+
+def test_make_live_mesh_rejects_unavailable_devices():
+    with pytest.raises(ValueError, match="only .* local JAX devices"):
+        make_live_mesh(jax.local_device_count() + 1, 16, 4)
+
+
+@pytest.mark.skipif(
+    not _HAS_FOUR_DEVICES,
+    reason="run with XLA_FLAGS=--xla_force_host_platform_device_count=4",
+)
+def test_nss_runs_sharded_and_preserves_diagnostics():
+    config = BlackJAXNSSConfig(
+        n_live=16,
+        n_delete_frac=0.25,
+        num_inner_steps_per_dim=1,
+        termination_dlogz=2.0,
+        n_devices=4,
+    )
+    sampler = BlackJAXNSSSampler(
+        n_dims=2,
+        log_prior_fn=_log_prior,
+        log_likelihood_fn=_log_likelihood,
+        log_posterior_fn=lambda x: _log_prior(x) + _log_likelihood(x),
+        config=config,
+    )
+
+    initial = jax.random.uniform(jax.random.key(0), (16, 2))
+    sampler.sample(jax.random.key(1), initial)
+    diagnostics = sampler.get_diagnostics()
+
+    assert diagnostics["n_iterations"] > 0
+    assert diagnostics["n_likelihood_evaluations"] > 0
+    stepping_out = diagnostics["n_stepping_out_history"]
+    assert stepping_out.shape[-1] == 2
+    assert stepping_out.shape[0] % config.n_devices == 0
+
+
+@pytest.mark.skipif(
+    not _HAS_FOUR_DEVICES,
+    reason="run with XLA_FLAGS=--xla_force_host_platform_device_count=4",
+)
+def test_swig_runs_sharded_with_consistent_cache():
+    config = BlackJAXSwiGConfig(
+        blocks=[["slow"], ["fast"]],
+        n_live=16,
+        n_delete_frac=0.25,
+        num_gibbs_sweeps=1,
+        max_steps=3,
+        max_shrinkage=20,
+        termination_dlogz=2.0,
+        n_devices=4,
+    )
+    sampler = BlackJAXSwiGSampler(
+        n_dims=2,
+        log_prior_fn=_log_prior,
+        log_likelihood_fn=_log_likelihood,
+        log_posterior_fn=lambda x: _log_prior(x) + _log_likelihood(x),
+        config=config,
+        block_indices=((0,), (1,)),
+        refresh_cache=(True, False),
+        build_cache_fn=_build_cache,
+        log_likelihood_from_cache_fn=_log_likelihood_from_cache,
+    )
+
+    initial = jax.random.uniform(jax.random.key(2), (16, 2))
+    sampler.sample(jax.random.key(3), initial)
+    result = sampler.get_samples()
+    expected = jax.vmap(_log_likelihood)(jnp.asarray(result["samples"]))
+
+    np.testing.assert_allclose(result["log_likelihood"], expected, rtol=2e-6)
+    assert sampler.get_diagnostics()["n_likelihood_evaluations"] > 0
+    assert not hasattr(sampler._final_state.particles, "cache")
+
+
+@pytest.mark.skipif(
+    not _HAS_FOUR_DEVICES,
+    reason="run with XLA_FLAGS=--xla_force_host_platform_device_count=4",
+)
+def test_sharded_checkpoint_is_host_backed_and_resumable(tmp_path, monkeypatch):
+    config = BlackJAXNSSConfig(
+        n_live=16,
+        n_delete_frac=0.25,
+        num_inner_steps_per_dim=1,
+        termination_dlogz=2.0,
+        n_devices=4,
+        checkpoint_dir=tmp_path,
+        checkpoint_interval=1e-9,
+    )
+
+    def make_sampler():
+        return BlackJAXNSSSampler(
+            n_dims=2,
+            log_prior_fn=_log_prior,
+            log_likelihood_fn=_log_likelihood,
+            log_posterior_fn=lambda x: _log_prior(x) + _log_likelihood(x),
+            config=config,
+        )
+
+    checkpoint = tmp_path / "checkpoint.pkl"
+    original_unlink = Path.unlink
+    monkeypatch.setattr(
+        Path,
+        "unlink",
+        lambda self, missing_ok=False: (
+            None if self == checkpoint else original_unlink(self, missing_ok=missing_ok)
+        ),
+    )
+    initial = jax.random.uniform(jax.random.key(4), (16, 2))
+    make_sampler().sample(jax.random.key(5), initial)
+    monkeypatch.setattr(Path, "unlink", original_unlink)
+
+    with checkpoint.open("rb") as stream:
+        saved = pickle.load(stream)
+    assert isinstance(saved["state"].particles.position, np.ndarray)
+
+    resumed = make_sampler()
+    resumed.sample(jax.random.key(999), initial)
+    assert resumed.get_diagnostics()["n_iterations"] > 0
+    assert not checkpoint.exists()

--- a/tests/unit/samplers/blackjax/test_smc.py
+++ b/tests/unit/samplers/blackjax/test_smc.py
@@ -440,6 +440,78 @@ def test_smc_resume_gives_same_result(tmp_path, monkeypatch):
     assert not (tmp_path / "checkpoint.pkl").exists(), "Checkpoint was not cleaned up"
 
 
+def test_smc_checkpoint_failure_restores_caller_rng_key(tmp_path):
+    """A checkpoint that fails *after* its rng_key is read (mode AP, the
+    default) falls back to the caller-supplied key, not the partially-loaded
+    checkpoint's key. The same fallback pattern is shared verbatim across all
+    four SMC modes.
+    """
+    prior = CombinePrior(
+        [
+            UniformPrior(0.0, 1.0, parameter_names=["x"]),
+            UniformPrior(0.0, 1.0, parameter_names=["y"]),
+        ]
+    )
+    likelihood = _GaussianLikelihood()
+    parameter_names = prior.parameter_names
+
+    def _make(checkpoint_dir=None):
+        config = BlackJAXSMCConfig(
+            n_particles=200,
+            n_mcmc_steps_per_dim=5,
+            target_ess=50,
+            initial_cov_scale=0.5,
+            target_acceptance_rate=0.234,
+            scale_adaptation_gain=3.0,
+            checkpoint_dir=checkpoint_dir,
+            checkpoint_interval=1e-9 if checkpoint_dir is not None else 0.0,
+        )
+
+        def log_prior_fn(arr):
+            return prior.log_prob(dict(zip(parameter_names, arr, strict=True)))
+
+        def log_likelihood_fn(arr):
+            return likelihood.evaluate(dict(zip(parameter_names, arr, strict=True)))
+
+        def log_posterior_fn(arr):
+            return log_prior_fn(arr) + log_likelihood_fn(arr)
+
+        return BlackJAXSMCSampler(
+            n_dims=len(parameter_names),
+            log_prior_fn=log_prior_fn,
+            log_likelihood_fn=log_likelihood_fn,
+            log_posterior_fn=log_posterior_fn,
+            config=config,
+        )
+
+    caller_key = jax.random.key(7)
+
+    reference = _make(checkpoint_dir=None)
+    reference.sample(caller_key, _init_pos(200))
+    log_z_reference = reference.get_diagnostics()["log_Z"]
+
+    sampler = _make(checkpoint_dir=tmp_path)
+    ckpt_path = tmp_path / "checkpoint.pkl"
+    # Valid enough to pass `_validate_checkpoint` and overwrite `rng_key` with
+    # a decoy key, but missing "n_iter" so loading fails right after.
+    with open(ckpt_path, "wb") as f:
+        pickle.dump(
+            {
+                "sampler_name": sampler.sampler_name,
+                "mode": sampler.mode,
+                "state": None,
+                "rng_key": jax.random.key(999),
+            },
+            f,
+        )
+
+    sampler.sample(caller_key, _init_pos(200))
+
+    assert sampler.get_diagnostics()["log_Z"] == pytest.approx(
+        log_z_reference, rel=1e-6
+    )
+
+
 def _make_sampler_batched(
     n_particles: int = 200, batch_size: int = 20
 ) -> BlackJAXSMCSampler:

--- a/tests/unit/samplers/blackjax/test_swig.py
+++ b/tests/unit/samplers/blackjax/test_swig.py
@@ -73,6 +73,31 @@ def test_swig_has_a_distinct_sampler_name():
     assert _make_sampler().sampler_name == "BlackJAX SwiG"
 
 
+def test_swig_forwards_n_devices_to_internal_nss_config():
+    """`n_devices` must reach the internally-built `BlackJAXNSSConfig` that
+    `_sample` actually reads — a value forwarded by hand across two Pydantic
+    models is easy to silently drop.
+    """
+    config = BlackJAXSwiGConfig(
+        blocks=[["slow"], ["fast"]],
+        n_live=24,
+        n_delete_frac=0.25,
+        termination_dlogz=1.5,
+        n_devices=2,
+    )
+    sampler = BlackJAXSwiGSampler(
+        n_dims=2,
+        log_prior_fn=_log_prior,
+        log_likelihood_fn=_log_likelihood,
+        log_posterior_fn=lambda x: _log_prior(x) + _log_likelihood(x),
+        config=config,
+        rebuild_required_by_block={(0,): True, (1,): False},
+        build_cache=_build_cache,
+        log_likelihood_from_cache_fn=_log_likelihood_from_cache,
+    )
+    assert sampler._config.n_devices == 2
+
+
 def test_swig_checkpoint_records_sampler_name(tmp_path, monkeypatch):
     sampler = _make_sampler(checkpoint_dir=tmp_path)
     checkpoint_path = tmp_path / "checkpoint.pkl"

--- a/tests/unit/samplers/test_config.py
+++ b/tests/unit/samplers/test_config.py
@@ -48,9 +48,7 @@ def test_sampler_config_union_from_dict():
     cfg4 = ta.validate_python({"type": "blackjax-smc"})
     assert isinstance(cfg4, BlackJAXSMCConfig)
 
-    cfg5 = ta.validate_python(
-        {"type": "blackjax-swig", "blocks": [["x"], ["y"]]}
-    )
+    cfg5 = ta.validate_python({"type": "blackjax-swig", "blocks": [["x"], ["y"]]})
     assert isinstance(cfg5, BlackJAXSwiGConfig)
 
 
@@ -67,6 +65,23 @@ def test_swig_sampling_defaults():
     config = BlackJAXSwiGConfig(blocks=[["x"]])
     assert config.num_gibbs_sweeps == 2
     assert config.termination_dlogz == pytest.approx(math.exp(-3.0))
+    assert config.n_devices == 1
+
+
+@pytest.mark.parametrize("config_cls", [BlackJAXNSSConfig, BlackJAXSwiGConfig])
+def test_nested_sampler_sharding_requires_divisible_particle_counts(config_cls):
+    kwargs = {"blocks": [["x"]]} if config_cls is BlackJAXSwiGConfig else {}
+    with pytest.raises(ValueError, match="n_live must be divisible by n_devices"):
+        config_cls(n_live=10, n_delete_frac=0.4, n_devices=4, **kwargs)
+    with pytest.raises(ValueError, match="n_delete must be divisible by n_devices"):
+        config_cls(n_live=12, n_delete_frac=0.25, n_devices=2, **kwargs)
+
+
+@pytest.mark.parametrize("config_cls", [BlackJAXNSSConfig, BlackJAXSwiGConfig])
+def test_nested_sampler_sharding_requires_positive_device_count(config_cls):
+    kwargs = {"blocks": [["x"]]} if config_cls is BlackJAXSwiGConfig else {}
+    with pytest.raises(ValueError, match="n_devices must be >= 1"):
+        config_cls(n_devices=0, **kwargs)
 
 
 def test_extra_fields_forbidden():

--- a/tests/unit/samplers/test_config.py
+++ b/tests/unit/samplers/test_config.py
@@ -94,7 +94,9 @@ def test_nested_sampler_sharding_requires_divisible_particle_counts(config_cls):
     kwargs = {"blocks": [["x"]]} if config_cls is BlackJAXSwiGConfig else {}
     with pytest.raises(ValidationError, match="n_live must be divisible by n_devices"):
         config_cls(n_live=10, n_delete_frac=0.4, n_devices=4, **kwargs)
-    with pytest.raises(ValidationError, match="n_delete must be divisible by n_devices"):
+    with pytest.raises(
+        ValidationError, match="n_delete must be divisible by n_devices"
+    ):
         config_cls(n_live=12, n_delete_frac=0.25, n_devices=2, **kwargs)
 
 


### PR DESCRIPTION
## Summary

Adds opt-in, single-host multi-device sharding to both BlackJAX NSS and the cache-aware Nested SwiG sampler introduced by #128.

- adds `n_devices` to `BlackJAXNSSConfig` and `BlackJAXSwiGConfig`, defaulting to the existing unsharded path
- shards live particles and replacement chains over a named JAX mesh while replicating the evidence integrator and adaptive covariance state
- uses one global likelihood all-gather for deletion and one full live-state all-gather for survivor starts per replacement
- keeps SwiG waveform caches ephemeral and device-local
- preserves the complete slice expansion, shrinkage, and acceptance diagnostics
- stores host-backed checkpoints and reshards state when resuming
- validates that `n_live` and `n_delete` are divisible by `n_devices`

This is a stacked PR targeting `codex/nested-swig-cache`. It should be retargeted to `jim-dev` after #128 merges.

## Validation

- `221 passed, 3 skipped` across `tests/unit/samplers` and the transient-likelihood unit suite
- `4 passed` with `XLA_FLAGS=--xla_force_host_platform_device_count=4`, covering:
  - sharded NSS execution and diagnostics
  - sharded cache-aware SwiG likelihood consistency
  - host-backed checkpointing and resume
  - unavailable-device validation
- Ruff lint and formatting checks pass

Real multi-GPU performance and scaling still need validation on the target GPU node.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end multi-device sharding for BlackJAX NSS and SwiG samplers.
  * Introduced the `n_devices` configuration option, including divisibility validation for live-point and deletion sizing.
  * Added updated sampler documentation and a GW150914 sharded sampling example with guidance for simulating multiple CPU devices.
* **Bug Fixes**
  * Improved robustness when checkpoint loading fails, ensuring correct RNG key handling and consistent resumability.
* **Tests**
  * Added integration and unit tests covering sharded runs, diagnostics, caching behaviour, sharding validation, and checkpoint recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->