### PR TITLE
Add differential-evolution kernel for SMC

### DIFF
--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -347,16 +347,30 @@ n_tempered_steps = 5
 
 | Field | Default | Description |
 | --- | --- | --- |
-| `n_particles` | `2000` | Number of particles |
+| `n_particles` | `5000` | Number of particles |
 | `n_mcmc_steps_per_dim` | `100` | MCMC steps per dimension per temperature |
 | `target_ess_fraction` | `0.9` | Optional — target effective sample size as a fraction of `n_particles`; use instead of `target_ess`, not both |
 | `target_ess` | — | Optional — target absolute ESS count; use instead of `target_ess_fraction`, not both |
-| `initial_cov_scale` | `0.5` | Initial covariance scale factor |
-| `target_acceptance_rate` | `0.234` | Target MCMC acceptance rate |
+| `inner_kernel` | `"GRW"` | Inner MCMC kernel: `"GRW"` or `"DE"` |
+| `grw.initial_cov_scale` | `0.5` | Initial covariance scale factor for GRW |
+| `grw.target_acceptance_rate` | `0.234` | Target MCMC acceptance rate for GRW |
+| `grw.scale_adaptation_gain` | `3.0` | Covariance-scale adaptation gain for GRW |
 | `persistent_sampling` | `true` | Reuse particles across temperatures |
 | `temperature_ladder` | — | Optional — fixed list of temperatures from 0.0 to 1.0; omit to use adaptive tempering |
 | `checkpoint_dir` | `{output.dir}/` | Directory for `checkpoint.pkl`; set by the CLI automatically |
 | `checkpoint_interval` | `600.0` | Seconds between checkpoint writes; `0` disables checkpointing |
+
+Configure GRW-specific settings in a nested TOML table:
+
+```toml
+[sampler.grw]
+initial_cov_scale = 0.5
+target_acceptance_rate = 0.234
+scale_adaptation_gain = 3.0
+```
+
+`"DE"` uses the differential-evolution acceptance-walk proposal and currently
+has no additional settings.
 
 ### `type = "blackjax-nss"`
 

--- a/src/jimgw/cli/_jim.py
+++ b/src/jimgw/cli/_jim.py
@@ -25,8 +25,7 @@ def _with_checkpoint(sampler_config, output_dir):
         update["checkpoint_interval"] = _CLI_CHECKPOINT_INTERVAL
     if not update:
         return sampler_config
-    merged = sampler_config.model_dump() | update
-    return sampler_config.__class__.model_validate(merged)
+    return sampler_config.model_copy(update=update)
 
 
 def build_jim(

--- a/src/jimgw/cli/_jim.py
+++ b/src/jimgw/cli/_jim.py
@@ -18,10 +18,16 @@ def _with_checkpoint(sampler_config, output_dir):
     ``{output_dir}/checkpoint.pkl``.
     """
     explicitly_set = sampler_config.model_fields_set
+    checkpointing_explicitly_disabled = (
+        "checkpoint_dir" in explicitly_set and sampler_config.checkpoint_dir is None
+    )
     update = {}
     if "checkpoint_dir" not in explicitly_set:
         update["checkpoint_dir"] = output_dir
-    if "checkpoint_interval" not in explicitly_set:
+    if (
+        "checkpoint_interval" not in explicitly_set
+        and not checkpointing_explicitly_disabled
+    ):
         update["checkpoint_interval"] = _CLI_CHECKPOINT_INTERVAL
     if not update:
         return sampler_config

--- a/src/jimgw/cli/_output.py
+++ b/src/jimgw/cli/_output.py
@@ -18,6 +18,25 @@ from jimgw.core.transforms import BijectiveTransform, NtoMTransform
 logger = logging.getLogger(__name__)
 
 
+def _resolved_config_data(cfg) -> dict:
+    """Serialize a pipeline config without inactive sampler sub-configs."""
+    dumped = cfg.model_dump(mode="json", exclude_none=True)
+    sampler = dumped.get("sampler", {})
+    if sampler.get("type") == "flowmc":
+        active_kernel = sampler["local_kernel"].lower()
+        kernel_names = ("mala", "hmc", "grw")
+    elif sampler.get("type") == "blackjax-smc":
+        active_kernel = sampler["inner_kernel"].lower()
+        kernel_names = ("grw", "de")
+    else:
+        return dumped
+
+    for kernel_name in kernel_names:
+        if kernel_name != active_kernel:
+            sampler.pop(kernel_name, None)
+    return dumped
+
+
 def write_outputs(jim, cfg) -> None:
     """Write samples, diagnostics, and optional corner plot under output.dir."""
 
@@ -62,12 +81,7 @@ def write_outputs(jim, cfg) -> None:
 
     # Resolved config
     cfg_path = out_dir / "config.final.toml"
-    dumped = cfg.model_dump(mode="json", exclude_none=True)
-    if dumped.get("sampler", {}).get("type") == "flowmc":
-        active = dumped["sampler"]["local_kernel"].lower()
-        for kernel in ("mala", "hmc", "grw"):
-            if kernel != active:
-                dumped["sampler"].pop(kernel, None)
+    dumped = _resolved_config_data(cfg)
     with open(cfg_path, "wb") as f:
         tomli_w.dump(dumped, f)
     logger.info("Saved resolved config to %s", cfg_path)

--- a/src/jimgw/samplers/blackjax/_acceptance_walk_kernel.py
+++ b/src/jimgw/samplers/blackjax/_acceptance_walk_kernel.py
@@ -37,6 +37,11 @@ from blackjax.ns.base import (
 from blackjax.types import ArrayLikeTree
 from jaxtyping import Array, Bool, Float, Key
 
+from jimgw.samplers.blackjax._de_move import (
+    de_proposal_scale,
+    sample_de_gamma,
+    sample_two_distinct_indices,
+)
 from jimgw.typing import FloatScalar, IntScalar
 
 
@@ -77,27 +82,22 @@ def _de_one_step(
 ):
     def body_fun(carry):
         _is_valid, key, _pos, _logp, count = carry
-        key_a, key_b, key_mix, key_gamma, new_key = jax.random.split(key, 5)
+        key_pair, key_gamma, new_key = jax.random.split(key, 3)
 
         _, top_indices = jax.lax.top_k(params.loglikelihoods, num_survivors)
-        pos_a = jax.random.randint(key_a, (), 0, num_survivors)
-        pos_b_raw = jax.random.randint(key_b, (), 0, num_survivors - 1)
-        pos_b = jnp.where(pos_b_raw >= pos_a, pos_b_raw + 1, pos_b_raw)
+        first_index, second_index = sample_two_distinct_indices(key_pair, num_survivors)
 
-        point_a = jax.tree_util.tree_map(
-            lambda x: x[top_indices[pos_a]], params.live_points
+        first_point = jax.tree_util.tree_map(
+            lambda x: x[top_indices[first_index]], params.live_points
         )
-        point_b = jax.tree_util.tree_map(
-            lambda x: x[top_indices[pos_b]], params.live_points
+        second_point = jax.tree_util.tree_map(
+            lambda x: x[top_indices[second_index]], params.live_points
         )
-        delta = jax.tree_util.tree_map(lambda a, b: a - b, point_a, point_b)
+        delta = jax.tree_util.tree_map(
+            lambda first, second: first - second, first_point, second_point
+        )
 
-        is_small_step = jax.random.uniform(key_mix) < params.mix
-        gamma = jnp.where(
-            is_small_step,
-            params.scale * jax.random.gamma(key_gamma, 4.0) * 0.25,
-            1.0,
-        )
+        gamma = sample_de_gamma(key_gamma, params.mix, params.scale)
 
         new_pos = stepper_fn(state.position, delta, gamma)
         new_logp = logprior_fn(new_pos)
@@ -278,7 +278,7 @@ def _update_bilby_walks(
         live_points=ns_state.particles.position,
         loglikelihoods=ns_state.particles.loglikelihood,
         mix=0.5,
-        scale=2.38 / jnp.sqrt(2 * n_dim),
+        scale=de_proposal_scale(n_dim),
         num_walks=jnp.array(num_walks_int, dtype=jnp.int32),
         walks_float=jnp.array(new_walks_float, dtype=jnp.float32),
         n_accept_total=jnp.array(0, dtype=jnp.int32),
@@ -358,18 +358,20 @@ def bilby_adaptive_de_sampler(
     base_kernel_step = build_adaptive_kernel(delete_fn, inner_kernel, update_fn)  # type: ignore[arg-type]  # blackjax stubs
 
     def init_fn(particles):
-        # Use lax.map instead of vmap to bound peak memory during init.
-        # A full vmap over all live particles materialises O(n_live) concurrent
-        # intermediate buffers, which can exhaust GPU memory for expensive likelihoods.
-        # Batching by num_delete caps peak to num_delete/nlive of the full-vmap cost.
-        _single_init_fn = partial(
+        """Initialize particle states in batches to bound peak GPU memory.
+
+        A full ``vmap`` over all live particles materializes concurrent
+        intermediate buffers. ``lax.map`` limits the batch to ``num_delete``
+        particles.
+        """
+        single_init_fn = partial(
             init_state_strategy,
             logprior_fn=logprior_fn,
             loglikelihood_fn=loglikelihood_fn,
         )
 
-        def _init_state_fn(positions):
-            return jax.lax.map(_single_init_fn, positions, batch_size=num_delete)
+        def init_state_fn(positions):
+            return jax.lax.map(single_init_fn, positions, batch_size=num_delete)
 
         def init_params_fn(rng_key, ns_state, info, current_params):
             example_particle = jax.tree_util.tree_map(
@@ -377,12 +379,11 @@ def bilby_adaptive_de_sampler(
             )
             flat_particle, _ = jax.flatten_util.ravel_pytree(example_particle)
             n_dim = flat_particle.shape[0]
-            scale = 2.38 / jnp.sqrt(2 * n_dim)
             initial_de_params = DEKernelParams(
                 live_points=ns_state.particles.position,
                 loglikelihoods=ns_state.particles.loglikelihood,
                 mix=0.5,
-                scale=scale,
+                scale=de_proposal_scale(n_dim),
                 num_walks=jnp.array(100, dtype=jnp.int32),
                 walks_float=jnp.array(100.0, dtype=jnp.float32),
                 n_accept_total=jnp.array(-1, dtype=jnp.int32),
@@ -391,7 +392,7 @@ def bilby_adaptive_de_sampler(
             return {"params": initial_de_params}
 
         return adaptive_init(
-            particles, _init_state_fn, update_inner_kernel_params_fn=init_params_fn
+            particles, init_state_fn, update_inner_kernel_params_fn=init_params_fn
         )
 
     def step_fn(rng_key, state: AdaptiveNSState):

--- a/src/jimgw/samplers/blackjax/_acceptance_walk_kernel.py
+++ b/src/jimgw/samplers/blackjax/_acceptance_walk_kernel.py
@@ -35,7 +35,7 @@ from blackjax.ns.base import (
     delete_fn as default_delete_fn,
 )
 from blackjax.types import ArrayLikeTree
-from jaxtyping import Array, Bool, Float, Key
+from jaxtyping import Array, Bool, Float, Int, Key
 
 from jimgw.samplers.blackjax._de_move import (
     de_proposal_scale,
@@ -78,13 +78,13 @@ def _de_one_step(
     params: DEKernelParams,
     stepper_fn,
     num_survivors: int,
+    top_indices: Int[Array, " num_survivors"],
     max_proposals: int = 1000,
 ):
     def body_fun(carry):
         _is_valid, key, _pos, _logp, count = carry
         key_pair, key_gamma, new_key = jax.random.split(key, 3)
 
-        _, top_indices = jax.lax.top_k(params.loglikelihoods, num_survivors)
         first_index, second_index = sample_two_distinct_indices(key_pair, num_survivors)
 
         first_point = jax.tree_util.tree_map(
@@ -146,9 +146,13 @@ def _de_walk(
     max_proposals: int = 1000,
     max_mcmc: int = 5000,
 ):
+    # top_indices is loop-invariant for the whole walk; compute it once here rather than inside _de_one_step's body_fun, since XLA won't hoist it out of the nested while_loops itself.
+    _, top_indices = jax.lax.top_k(params.loglikelihoods, num_survivors)
+
     one_step = partial(
         _de_one_step,
         num_survivors=num_survivors,
+        top_indices=top_indices,
         max_proposals=max_proposals,
     )
 

--- a/src/jimgw/samplers/blackjax/_de_move.py
+++ b/src/jimgw/samplers/blackjax/_de_move.py
@@ -1,0 +1,46 @@
+"""Shared proposal primitives for differential-evolution samplers.
+
+The nested-sampling acceptance-walk and SMC inner kernels use the same
+proposal, but apply different acceptance rules.
+"""
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import Key
+
+from jimgw.typing import FloatScalar, IntScalar
+
+
+def sample_two_distinct_indices(
+    key: Key, population_size: int
+) -> tuple[IntScalar, IntScalar]:
+    """Sample two distinct indices uniformly from a population."""
+    key_a, key_b = jax.random.split(key)
+    idx_a = jax.random.randint(key_a, (), 0, population_size)
+    idx_b_raw = jax.random.randint(key_b, (), 0, population_size - 1)
+    idx_b = jnp.where(idx_b_raw >= idx_a, idx_b_raw + 1, idx_b_raw)
+    return idx_a, idx_b
+
+
+def sample_de_gamma(
+    key: Key,
+    small_step_probability: float,
+    small_step_scale: FloatScalar,
+) -> FloatScalar:
+    """Sample a small gamma-distributed multiplier or a unit DE multiplier.
+
+    A small step is used with ``small_step_probability``; otherwise the unit
+    multiplier makes a mode-hopping proposal.
+    """
+    key_mix, key_gamma = jax.random.split(key)
+    is_small_step = jax.random.uniform(key_mix) < small_step_probability
+    return jnp.where(
+        is_small_step,
+        small_step_scale * jax.random.gamma(key_gamma, 4.0) * 0.25,
+        1.0,
+    )
+
+
+def de_proposal_scale(n_dimensions: int) -> FloatScalar:
+    """Return the ter Braak (2006) DE-MC scale for ``n_dimensions``."""
+    return 2.38 / jnp.sqrt(2.0 * n_dimensions)

--- a/src/jimgw/samplers/blackjax/ns_aw.py
+++ b/src/jimgw/samplers/blackjax/ns_aw.py
@@ -1,8 +1,5 @@
 """BlackJAX nested sampling with bilby/dynesty-style adaptive DE acceptance-walk kernel."""
 
-import logging
-import pickle
-import shutil
 import time
 from collections.abc import Callable
 from typing import Any, Optional
@@ -18,10 +15,14 @@ from jaxtyping import Array, Float, Key
 
 from jimgw.samplers.base import Sampler
 from jimgw.samplers.blackjax._acceptance_walk_kernel import bilby_adaptive_de_sampler
+from jimgw.samplers.blackjax.utils import (
+    load_or_initialize_checkpoint,
+    prepare_checkpointing,
+    remove_checkpoint_and_jax_cache,
+    save_checkpoint_if_due,
+)
 from jimgw.samplers.config import BlackJAXNSAWConfig
 from jimgw.samplers.periodic import to_unit_cube_stepper
-
-logger = logging.getLogger(__name__)
 
 
 class BlackJAXNSAWSampler(Sampler):
@@ -138,13 +139,7 @@ class BlackJAXNSAWSampler(Sampler):
         config = self._config
         n_live = config.n_live
         n_delete = int(n_live * config.n_delete_frac)
-        checkpoint_path = (
-            config.checkpoint_dir / "checkpoint.pkl"
-            if config.checkpoint_dir is not None
-            else None
-        )
-        config.configure_jax_cache()
-        run_started_at = time.perf_counter()
+        checkpoint_path, run_start_time = prepare_checkpointing(config)
 
         def validate_initial_particles(pos):
             arr = jnp.asarray(pos)
@@ -166,84 +161,43 @@ class BlackJAXNSAWSampler(Sampler):
             max_proposals=config.max_proposals,
         )
 
-        # Resume from checkpoint if one exists.
-        if (
-            checkpoint_path is not None
-            and config.checkpoint_interval > 0
-            and checkpoint_path.exists()
-        ):
-            initial_rng_key = rng_key
-            try:
-                with open(checkpoint_path, "rb") as checkpoint_file:
-                    checkpoint = pickle.load(checkpoint_file)
-                self._validate_checkpoint(checkpoint)
-                state = checkpoint["state"]
-                dead = checkpoint["dead"]
-                rng_key = checkpoint["rng_key"]
-                n_completed_iterations = checkpoint["n_iter"]
-                self._prev_elapsed = float(checkpoint["elapsed_time"])
-                logger.info(
-                    "%s: resumed from checkpoint at n_iter=%d (%s)",
-                    self.sampler_name,
-                    n_completed_iterations,
-                    checkpoint_path,
-                )
-            except (
-                OSError,
-                EOFError,
-                KeyError,
-                TypeError,
-                ValueError,
-                pickle.UnpicklingError,
-            ) as error:
-                logger.warning(
-                    "%s: incompatible or corrupt checkpoint at %s (%s) — starting fresh.",
-                    self.sampler_name,
-                    checkpoint_path,
-                    error,
-                )
-                rng_key = initial_rng_key
-                state = nested_sampler.init(
-                    validate_initial_particles(initial_position)
-                )  # type: ignore[call-arg]  # blackjax API
-                dead = []
-                n_completed_iterations = 0
-                self._prev_elapsed = 0.0
-        else:
-            state = nested_sampler.init(validate_initial_particles(initial_position))  # type: ignore[call-arg]  # blackjax API
-            dead = []
-            n_completed_iterations = 0
+        state, rng_key, n_completed_iterations, extra = load_or_initialize_checkpoint(
+            self,
+            checkpoint_path,
+            config,
+            rng_key,
+            initial_position,
+            lambda position: nested_sampler.init(validate_initial_particles(position)),  # type: ignore[call-arg]  # blackjax API
+            initial_extra={"dead": []},
+            load_extra=lambda checkpoint: {"dead": checkpoint["dead"]},
+            log_label=self.sampler_name,
+        )
+        dead = extra["dead"]
 
         def should_terminate(state: AdaptiveNSState) -> bool:
             dlogz = jnp.logaddexp(0, state.integrator.logZ_live - state.integrator.logZ)
             return bool(jnp.isfinite(dlogz) and dlogz < config.termination_dlogz)
 
         step_fn = jax.jit(nested_sampler.step)
-        last_checkpoint_at = time.perf_counter()
+        last_checkpoint_write_time = time.perf_counter()
 
         while not should_terminate(state):
             rng_key, step_key = jax.random.split(rng_key)
             state, dead_info = step_fn(step_key, state)
             dead.append(dead_info)
             n_completed_iterations += 1
-            if (
-                checkpoint_path is not None
-                and config.checkpoint_interval > 0
-                and time.perf_counter() - last_checkpoint_at
-                >= config.checkpoint_interval
-            ):
-                last_checkpoint_at = config.write_checkpoint(
-                    {
-                        "state": state,
-                        "dead": dead,
-                        "rng_key": rng_key,
-                        "n_iter": n_completed_iterations,
-                        "sampler_name": self.sampler_name,
-                        "elapsed_time": self._prev_elapsed
-                        + (time.perf_counter() - run_started_at),
-                    },
-                    self.sampler_name,
-                )
+            last_checkpoint_write_time = save_checkpoint_if_due(
+                self,
+                config,
+                checkpoint_path,
+                last_checkpoint_write_time,
+                run_start_time,
+                state,
+                rng_key,
+                n_completed_iterations,
+                {"dead": dead},
+                log_label=self.sampler_name,
+            )
 
         self._final_state = finalise(state, dead)
         self._n_iterations = n_completed_iterations
@@ -260,11 +214,7 @@ class BlackJAXNSAWSampler(Sampler):
             logzero=np.nan,
             dtype=np.float64,
         )
-        if checkpoint_path is not None:
-            checkpoint_path.unlink(missing_ok=True)
-        if config.checkpoint_dir is not None:
-            shutil.rmtree(config.checkpoint_dir / "jax_cache", ignore_errors=True)
-            jax.config.update("jax_compilation_cache_dir", None)
+        remove_checkpoint_and_jax_cache(config, checkpoint_path)
 
     def get_samples(self) -> dict[str, np.ndarray]:
         """Return equally-weighted posterior samples.

--- a/src/jimgw/samplers/blackjax/nss.py
+++ b/src/jimgw/samplers/blackjax/nss.py
@@ -258,7 +258,9 @@ class BlackJAXNSSSampler(Sampler):
                 ),
             )
 
-        final_state = finalise(state, dead)  # type: ignore[arg-type]  # AdaptiveNSState structurally satisfies NSState (.particles field)
+        final_state = finalise(
+            state, dead
+        )  # AdaptiveNSState structurally satisfies NSState (.particles field)
         self._final_state = jax.device_get(final_state)
         self._n_iterations = n_completed_iterations
 

--- a/src/jimgw/samplers/blackjax/nss.py
+++ b/src/jimgw/samplers/blackjax/nss.py
@@ -1,8 +1,5 @@
 """BlackJAX Nested Slice Sampling (NSS)."""
 
-import logging
-import pickle
-import shutil
 import time
 from collections.abc import Callable
 from functools import partial
@@ -37,10 +34,14 @@ from jimgw.samplers.blackjax.sharding import (
     place_key,
     place_state,
 )
+from jimgw.samplers.blackjax.utils import (
+    load_or_initialize_checkpoint,
+    prepare_checkpointing,
+    remove_checkpoint_and_jax_cache,
+    save_checkpoint_if_due,
+)
 from jimgw.samplers.config import BlackJAXNSSConfig
 from jimgw.samplers.periodic import to_prior_space_proposal
-
-logger = logging.getLogger(__name__)
 
 
 class BlackJAXNSSSampler(Sampler):
@@ -165,13 +166,7 @@ class BlackJAXNSSSampler(Sampler):
         n_live = config.n_live
         n_delete = int(n_live * config.n_delete_frac)
         mesh = make_live_mesh(config.n_devices, n_live, n_delete)
-        checkpoint_path = (
-            config.checkpoint_dir / "checkpoint.pkl"
-            if config.checkpoint_dir is not None
-            else None
-        )
-        config.configure_jax_cache()
-        run_started_at = time.perf_counter()
+        checkpoint_path, run_start_time = prepare_checkpointing(config)
 
         def validate_initial_particles(pos):
             arr = jnp.asarray(pos)
@@ -212,58 +207,23 @@ class BlackJAXNSSSampler(Sampler):
             )
             return place_state(state, mesh) if mesh is not None else state
 
-        # Resume from checkpoint if one exists.
-        if (
-            checkpoint_path is not None
-            and config.checkpoint_interval > 0
-            and checkpoint_path.exists()
-        ):
-            initial_rng_key = rng_key
-            try:
-                with open(checkpoint_path, "rb") as checkpoint_file:
-                    checkpoint = pickle.load(checkpoint_file)
-                self._validate_checkpoint(checkpoint)
-                state = checkpoint["state"]
-                dead = checkpoint["dead"]
-                rng_key = checkpoint["rng_key"]
-                if mesh is not None:
-                    state = place_state(state, mesh)
-                    rng_key = place_key(rng_key, mesh)
-                n_completed_iterations = checkpoint["n_iter"]
-                self._prev_elapsed = float(checkpoint["elapsed_time"])
-                logger.info(
-                    "%s: resumed from checkpoint at n_iter=%d (%s)",
-                    self.sampler_name,
-                    n_completed_iterations,
-                    checkpoint_path,
-                )
-            except (
-                OSError,
-                EOFError,
-                KeyError,
-                TypeError,
-                ValueError,
-                pickle.UnpicklingError,
-            ) as error:
-                logger.warning(
-                    "%s: incompatible or corrupt checkpoint at %s (%s) — starting fresh.",
-                    self.sampler_name,
-                    checkpoint_path,
-                    error,
-                )
-                rng_key = initial_rng_key
-                state = initialize_nested_sampler_state(
-                    validate_initial_particles(initial_position)
-                )
-                dead = []
-                n_completed_iterations = 0
-                self._prev_elapsed = 0.0
-        else:
-            state = initialize_nested_sampler_state(
-                validate_initial_particles(initial_position)
-            )
-            dead = []
-            n_completed_iterations = 0
+        state, rng_key, n_completed_iterations, extra = load_or_initialize_checkpoint(
+            self,
+            checkpoint_path,
+            config,
+            rng_key,
+            initial_position,
+            lambda position: initialize_nested_sampler_state(
+                validate_initial_particles(position)
+            ),
+            initial_extra={"dead": []},
+            load_extra=lambda checkpoint: {"dead": checkpoint["dead"]},
+            log_label=self.sampler_name,
+            after_load=lambda state: (
+                place_state(state, mesh) if mesh is not None else state
+            ),
+        )
+        dead = extra["dead"]
 
         if mesh is not None:
             rng_key = place_key(rng_key, mesh)
@@ -273,31 +233,30 @@ class BlackJAXNSSSampler(Sampler):
             return bool(jnp.isfinite(dlogz) and dlogz < config.termination_dlogz)
 
         step_fn = jax.jit(nested_sampler.step)
-        last_checkpoint_at = time.perf_counter()
+        last_checkpoint_write_time = time.perf_counter()
 
         while not should_terminate(state):
             rng_key, step_key = jax.random.split(rng_key)
             state, dead_info = step_fn(step_key, state)
             dead.append(dead_info)
             n_completed_iterations += 1
-            if (
-                checkpoint_path is not None
-                and config.checkpoint_interval > 0
-                and time.perf_counter() - last_checkpoint_at
-                >= config.checkpoint_interval
-            ):
-                last_checkpoint_at = config.write_checkpoint(
-                    {
-                        "state": jax.device_get(state),
-                        "dead": jax.device_get(dead),
-                        "rng_key": jax.device_get(rng_key),
-                        "n_iter": n_completed_iterations,
-                        "sampler_name": self.sampler_name,
-                        "elapsed_time": self._prev_elapsed
-                        + (time.perf_counter() - run_started_at),
-                    },
-                    self.sampler_name,
-                )
+            last_checkpoint_write_time = save_checkpoint_if_due(
+                self,
+                config,
+                checkpoint_path,
+                last_checkpoint_write_time,
+                run_start_time,
+                state,
+                rng_key,
+                n_completed_iterations,
+                {"dead": dead},
+                log_label=self.sampler_name,
+                before_save=lambda state, rng_key, extra: (
+                    jax.device_get(state),
+                    jax.device_get(rng_key),
+                    jax.device_get(extra),
+                ),
+            )
 
         final_state = finalise(state, dead)  # type: ignore[arg-type]  # AdaptiveNSState structurally satisfies NSState (.particles field)
         self._final_state = jax.device_get(final_state)
@@ -315,11 +274,7 @@ class BlackJAXNSSSampler(Sampler):
             logzero=np.nan,
             dtype=np.float64,
         )
-        if checkpoint_path is not None:
-            checkpoint_path.unlink(missing_ok=True)
-        if config.checkpoint_dir is not None:
-            shutil.rmtree(config.checkpoint_dir / "jax_cache", ignore_errors=True)
-            jax.config.update("jax_compilation_cache_dir", None)
+        remove_checkpoint_and_jax_cache(config, checkpoint_path)
 
     def get_samples(self) -> dict[str, np.ndarray]:
         """Return equally-weighted posterior samples via anesthetic's ``posterior_points``.

--- a/src/jimgw/samplers/blackjax/smc.py
+++ b/src/jimgw/samplers/blackjax/smc.py
@@ -29,7 +29,7 @@ from blackjax import (
     tempered_smc,
 )
 from blackjax.mcmc import random_walk
-from blackjax.smc import extend_params
+from blackjax.smc import extend_params, persistent_sampling, tempered
 from blackjax.smc.inner_kernel_tuning import StateWithParameterOverride
 from blackjax.smc.persistent_sampling import (
     compute_log_persistent_weights,
@@ -39,6 +39,11 @@ from blackjax.smc.resampling import systematic
 from jaxtyping import Array, Float, Key
 
 from jimgw.samplers.base import Sampler
+from jimgw.samplers.blackjax._de_move import (
+    de_proposal_scale,
+    sample_de_gamma,
+    sample_two_distinct_indices,
+)
 from jimgw.samplers.config import BlackJAXSMCConfig
 from jimgw.samplers.periodic import to_displacement_wrapper
 
@@ -51,9 +56,9 @@ _RESAMPLE_KEY = jax.random.key(123)
 class BlackJAXSMCSampler(Sampler):
     """BlackJAX SMC sampler.
 
-    Uses a Gaussian random-walk MCMC inner kernel with initial covariance
-    estimated from the starting particles.  With adaptive temperature
-    selection the covariance is re-estimated at each step.
+    The inner kernel is set by ``config.inner_kernel``: ``"GRW"`` (default) is a
+    Gaussian random walk with adaptive covariance; ``"DE"`` uses the
+    differential-evolution proposal shared with the NS acceptance-walk kernel.
 
     Supports checkpoint/resume via ``config.checkpoint_dir``: a ``checkpoint.pkl``
     checkpoint is written atomically after each tempering iteration (subject
@@ -131,93 +136,229 @@ class BlackJAXSMCSampler(Sampler):
                 "checkpoint belongs to a different SMC mode: "
                 f"{checkpoint_mode or 'an unknown mode'}, not {self.mode}"
             )
+        checkpoint_kernel = checkpoint.get("inner_kernel")
+        if checkpoint_kernel != self._config.inner_kernel:
+            raise ValueError(
+                "checkpoint belongs to a different SMC inner kernel: "
+                f"{checkpoint_kernel}, not {self._config.inner_kernel}"
+            )
 
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
+    def _build_inner_kernel_step(self):
+        """Build the transition step for the configured inner kernel.
 
-    def _build_mcmc_step(self):
-        """Return a GRW step callable ``(key, state, logdensity, cov) -> (state, info)``."""
+        The returned function accepts ``(key, state, logdensity, parameter)``.
+        Its parameter is a covariance matrix for GRW or a reference ensemble for
+        differential evolution.
+        """
         displacement_wrapper = self._displacement_wrapper
-        kernel = random_walk.build_additive_step()
+        additive_step = random_walk.build_additive_step()
 
-        def step(key, state, logdensity, cov):
-            def proposal_distribution(key, position):
-                raw_disp = jax.random.multivariate_normal(
-                    key, jnp.zeros_like(position), cov
+        if self._config.inner_kernel == "GRW":
+
+            def grw_step(random_key, state, logdensity, cov):
+                covariance = cov
+
+                def proposal_distribution(proposal_key, position):
+                    raw_disp = jax.random.multivariate_normal(
+                        proposal_key, jnp.zeros_like(position), covariance
+                    )
+                    return displacement_wrapper(raw_disp, position)
+
+                return additive_step(
+                    random_key, state, logdensity, proposal_distribution
                 )
-                return displacement_wrapper(raw_disp, position)
 
-            return kernel(key, state, logdensity, proposal_distribution)
+            return grw_step
 
-        return step
+        proposal_scale = de_proposal_scale(self.n_dims)
+        small_step_probability = 0.5
 
-    def _resume_or_init_state(
+        def de_step(random_key, state, logdensity, ensemble):
+            reference_ensemble = ensemble
+            n_particles = reference_ensemble.shape[0]
+
+            def proposal_distribution(proposal_key, position):
+                pair_key, multiplier_key = jax.random.split(proposal_key)
+                first_index, second_index = sample_two_distinct_indices(
+                    pair_key, n_particles
+                )
+                ensemble_difference = (
+                    reference_ensemble[first_index] - reference_ensemble[second_index]
+                )
+                multiplier = sample_de_gamma(
+                    multiplier_key, small_step_probability, proposal_scale
+                )
+                return displacement_wrapper(multiplier * ensemble_difference, position)
+
+            return additive_step(random_key, state, logdensity, proposal_distribution)
+
+        return de_step
+
+    def _build_adaptive_inner_kernel_parameters(self, initial_particles):
+        """Build the parameter updater and initial values for adaptive SMC.
+
+        GRW receives a covariance estimated from the particle cloud. Differential
+        evolution receives that cloud itself as its proposal reference ensemble.
+        """
+        if self._config.inner_kernel == "DE":
+
+            def update_ensemble_parameters(_key, smc_state, _info):
+                return extend_params({"ensemble": smc_state.particles})  # type: ignore[arg-type]
+
+            return update_ensemble_parameters, extend_params(
+                {"ensemble": initial_particles}  # type: ignore[arg-type]
+            )
+
+        initial_covariance = (
+            jnp.atleast_2d(jnp.cov(initial_particles.T))
+            * self._config.grw.initial_cov_scale
+        )
+
+        def update_covariance_parameters(_key, smc_state, _info):
+            covariance = jnp.atleast_2d(jnp.cov(smc_state.particles.T))
+            return extend_params({"cov": covariance})  # type: ignore[arg-type]
+
+        return update_covariance_parameters, extend_params(
+            {"cov": initial_covariance}  # type: ignore[arg-type]
+        )
+
+    def _build_fixed_ladder_smc(
         self,
-        ckpt_path: Optional[Path],
+        uses_persistent_sampling: bool,
+        inner_kernel_step,
+        initial_particles,
+        n_temperature_steps: int,
+        n_mcmc_steps: int,
+    ):
+        """Build initialization and transition functions for a fixed temperature ladder.
+
+        GRW uses BlackJAX's high-level SMC algorithms. The DE path builds the
+        underlying transition directly so each step can use the latest particle
+        cloud as its proposal reference ensemble.
+        """
+        config = self._config
+
+        if config.inner_kernel == "DE":
+            build_smc_transition = (
+                persistent_sampling.build_kernel
+                if uses_persistent_sampling
+                else tempered.build_kernel
+            )
+            smc_transition = build_smc_transition(
+                logprior_fn=self._log_prior_fn,
+                loglikelihood_fn=self._log_likelihood_fn,
+                mcmc_step_fn=inner_kernel_step,
+                mcmc_init_fn=rmh.init,
+                resampling_fn=systematic,
+                batch_size=config.batch_size,
+            )
+
+            def initialize_de_state(particles):
+                if uses_persistent_sampling:
+                    return persistent_sampling.init(
+                        particles,
+                        self._log_likelihood_fn,
+                        n_temperature_steps,
+                        batch_size=config.batch_size,
+                    )
+                return tempered.init(particles)
+
+            def step_with_current_ensemble(random_key, state, tempering_parameter):
+                return smc_transition(
+                    random_key,
+                    state,
+                    n_mcmc_steps,
+                    tempering_parameter,
+                    extend_params({"ensemble": state.particles}),  # type: ignore[arg-type]
+                )
+
+            return initialize_de_state, step_with_current_ensemble
+
+        initial_covariance = (
+            jnp.atleast_2d(jnp.cov(initial_particles.T)) * config.grw.initial_cov_scale
+        )
+        smc_kwargs = {
+            "logprior_fn": self._log_prior_fn,
+            "loglikelihood_fn": self._log_likelihood_fn,
+            "mcmc_step_fn": inner_kernel_step,
+            "mcmc_init_fn": rmh.init,
+            "mcmc_parameters": extend_params({"cov": initial_covariance}),  # type: ignore[arg-type]
+            "resampling_fn": systematic,
+            "num_mcmc_steps": n_mcmc_steps,
+            "batch_size": config.batch_size,
+        }
+        smc_algorithm = (
+            persistent_sampling_smc(n_schedule=n_temperature_steps, **smc_kwargs)
+            if uses_persistent_sampling
+            else tempered_smc(**smc_kwargs)
+        )
+        return smc_algorithm.init, smc_algorithm.step
+
+    def _load_or_initialize_state(
+        self,
+        checkpoint_path: Optional[Path],
         config: BlackJAXSMCConfig,
         rng_key: Key,
         initial_particles,
-        smc_alg,
-        fresh_extra: dict[str, Any],
-        restore_extra: Callable[[dict], dict[str, Any]],
-        n_schedule: Optional[int] = None,
+        initialize_state: Callable,
+        initial_mode_data: dict[str, Any],
+        load_mode_data: Callable[[dict], dict[str, Any]],
+        n_temperature_steps: Optional[int] = None,
     ) -> tuple[Any, Key, int, dict[str, Any]]:
-        """Resume ``(state, rng_key, n_iter, extra)`` from a checkpoint, or init fresh.
+        """Load a compatible checkpoint or initialize a new SMC state.
 
-        ``restore_extra`` maps a loaded checkpoint dict to the mode-specific
-        history fields (e.g. acceptance/covariance/tempering history);
-        ``fresh_extra`` is used whenever sampling starts fresh — no
-        checkpoint, an incompatible/corrupt one, or (fixed-ladder modes
-        only, via ``n_schedule``) a checkpoint whose ``n_iter`` exceeds the
-        current schedule length. Sets ``self._prev_elapsed`` as a side
-        effect, matching each mode's previous per-branch behavior.
+        ``load_mode_data`` restores histories that are specific to each SMC
+        mode. ``initial_mode_data`` is used when no usable checkpoint exists or
+        when a fixed-ladder checkpoint exceeds the current number of temperature
+        steps. Only trusted checkpoint files may be loaded because pickle can
+        execute arbitrary code.
         """
         if not (
-            ckpt_path is not None
+            checkpoint_path is not None
             and config.checkpoint_interval > 0
-            and ckpt_path.exists()
+            and checkpoint_path.exists()
         ):
             self._prev_elapsed = 0.0
             return (
-                smc_alg.init(initial_particles),
+                initialize_state(initial_particles),
                 rng_key,
                 0,
-                dict(fresh_extra),
+                dict(initial_mode_data),
             )
 
-        _initial_rng_key = rng_key
+        initial_rng_key = rng_key
         try:
-            with open(ckpt_path, "rb") as _f:
-                _ckpt = pickle.load(
-                    _f
-                )  # Only load trusted checkpoints — pickle executes arbitrary code.
-            self._validate_checkpoint(_ckpt)
-            state = _ckpt["state"]
-            rng_key = _ckpt["rng_key"]
-            n_iter = _ckpt["n_iter"]
-            extra = restore_extra(_ckpt)
-            if n_schedule is not None and n_iter > n_schedule:
+            with open(checkpoint_path, "rb") as checkpoint_file:
+                checkpoint = pickle.load(checkpoint_file)
+            self._validate_checkpoint(checkpoint)
+            state = checkpoint["state"]
+            rng_key = checkpoint["rng_key"]
+            n_completed_iterations = checkpoint["n_iter"]
+            mode_data = load_mode_data(checkpoint)
+            if (
+                n_temperature_steps is not None
+                and n_completed_iterations > n_temperature_steps
+            ):
                 logger.warning(
                     "%s: checkpoint n_iter=%d exceeds current schedule length=%d — starting fresh.",
                     f"{self.sampler_name} ({self.mode.upper()})",
-                    n_iter,
-                    n_schedule,
+                    n_completed_iterations,
+                    n_temperature_steps,
                 )
-                rng_key = _initial_rng_key
-                state = smc_alg.init(initial_particles)
-                n_iter = 0
-                extra = dict(fresh_extra)
+                rng_key = initial_rng_key
+                state = initialize_state(initial_particles)
+                n_completed_iterations = 0
+                mode_data = dict(initial_mode_data)
                 self._prev_elapsed = 0.0
             else:
-                self._prev_elapsed = float(_ckpt["elapsed_time"])
+                self._prev_elapsed = float(checkpoint["elapsed_time"])
                 logger.info(
                     "%s: resumed from checkpoint at n_iter=%d (%s)",
                     f"{self.sampler_name} ({self.mode.upper()})",
-                    n_iter,
-                    ckpt_path,
+                    n_completed_iterations,
+                    checkpoint_path,
                 )
-            return state, rng_key, n_iter, extra
+            return state, rng_key, n_completed_iterations, mode_data
         except (
             OSError,
             EOFError,
@@ -225,409 +366,401 @@ class BlackJAXSMCSampler(Sampler):
             TypeError,
             ValueError,
             pickle.UnpicklingError,
-        ) as _e:
+        ) as error:
             logger.warning(
                 "%s: incompatible or corrupt checkpoint at %s (%s) — starting fresh.",
                 f"{self.sampler_name} ({self.mode.upper()})",
-                ckpt_path,
-                _e,
+                checkpoint_path,
+                error,
             )
             self._prev_elapsed = 0.0
             return (
-                smc_alg.init(initial_particles),
-                _initial_rng_key,
+                initialize_state(initial_particles),
+                initial_rng_key,
                 0,
-                dict(fresh_extra),
+                dict(initial_mode_data),
             )
 
-    # ------------------------------------------------------------------
-    # Mode runners
-    # ------------------------------------------------------------------
-
-    def _run_adaptive_persistent(self, rng_key: Key, initial_particles) -> None:
-        """Mode AP: adaptive_persistent_sampling_smc + inner_kernel_tuning + Python while."""
-        config = self._config
-        n_mcmc_steps = config.n_mcmc_steps_per_dim * self.n_dims
-        target_ess = config._resolve_target_ess_fraction()
-        ckpt_path = (
+    def _prepare_checkpointing(
+        self, config: BlackJAXSMCConfig
+    ) -> tuple[Optional[Path], float]:
+        """Enable the JAX compile cache and return the checkpoint path and start time."""
+        checkpoint_path = (
             config.checkpoint_dir / "checkpoint.pkl"
             if config.checkpoint_dir is not None
             else None
         )
         config.configure_jax_cache()
-        _method_t0 = time.perf_counter()
+        return checkpoint_path, time.perf_counter()
 
-        mcmc_step = self._build_mcmc_step()
-        cov0 = jnp.atleast_2d(jnp.cov(initial_particles.T)) * config.initial_cov_scale
+    def _save_checkpoint_if_due(
+        self,
+        config: BlackJAXSMCConfig,
+        checkpoint_path: Optional[Path],
+        last_checkpoint_at: float,
+        run_started_at: float,
+        state: Any,
+        rng_key: Key,
+        n_completed_iterations: int,
+        mode_data: dict[str, Any],
+    ) -> float:
+        """Save a checkpoint when its interval has elapsed.
 
-        def mcmc_parameter_update_fn(_key, state, _info):
-            return extend_params({"cov": jnp.atleast_2d(jnp.cov(state.particles.T))})  # type: ignore[arg-type]  # blackjax stubs: extend_params accepts dict
+        ``mode_data`` contains mode-specific histories to merge into the common
+        checkpoint data. Returns the last checkpoint time.
+        """
+        if not (
+            checkpoint_path is not None
+            and config.checkpoint_interval > 0
+            and time.perf_counter() - last_checkpoint_at >= config.checkpoint_interval
+        ):
+            return last_checkpoint_at
+        return config.write_checkpoint(
+            {
+                "state": state,
+                "rng_key": rng_key,
+                "n_iter": n_completed_iterations,
+                "mode": self.mode,
+                "inner_kernel": config.inner_kernel,
+                "sampler_name": self.sampler_name,
+                "elapsed_time": self._prev_elapsed
+                + (time.perf_counter() - run_started_at),
+                **mode_data,
+            },
+            f"{self.sampler_name} ({self.mode.upper()})",
+        )
 
-        smc_alg = inner_kernel_tuning(
+    def _remove_checkpoint_and_jax_cache(
+        self, config: BlackJAXSMCConfig, checkpoint_path: Optional[Path]
+    ) -> None:
+        """Remove a completed run's checkpoint, JAX cache, and cache setting."""
+        if checkpoint_path is not None:
+            checkpoint_path.unlink(missing_ok=True)
+        if config.checkpoint_dir is not None:
+            shutil.rmtree(config.checkpoint_dir / "jax_cache", ignore_errors=True)
+            jax.config.update("jax_compilation_cache_dir", None)
+
+    def _run_adaptive_persistent(self, rng_key: Key, initial_particles) -> None:
+        """Run adaptive persistent SMC with the configured inner kernel."""
+        config = self._config
+        n_mcmc_steps = config.n_mcmc_steps_per_dim * self.n_dims
+        target_ess = config._resolve_target_ess_fraction()
+        checkpoint_path, run_started_at = self._prepare_checkpointing(config)
+
+        inner_kernel_step = self._build_inner_kernel_step()
+        update_mcmc_parameters, initial_mcmc_parameters = (
+            self._build_adaptive_inner_kernel_parameters(initial_particles)
+        )
+
+        smc_algorithm = inner_kernel_tuning(
             smc_algorithm=adaptive_persistent_sampling_smc,
             logprior_fn=self._log_prior_fn,
             loglikelihood_fn=self._log_likelihood_fn,
             max_iterations=1000,
-            mcmc_step_fn=mcmc_step,
+            mcmc_step_fn=inner_kernel_step,
             mcmc_init_fn=rmh.init,
             resampling_fn=systematic,
-            mcmc_parameter_update_fn=mcmc_parameter_update_fn,
-            initial_parameter_value=extend_params({"cov": cov0}),  # type: ignore[arg-type]  # blackjax stubs: extend_params accepts dict
+            mcmc_parameter_update_fn=update_mcmc_parameters,
+            initial_parameter_value=initial_mcmc_parameters,
             num_mcmc_steps=n_mcmc_steps,
             target_ess=target_ess,
             batch_size=config.batch_size,
         )
 
-        cov_scale = float(config.initial_cov_scale)
-        state, rng_key, n_iter, _extra = self._resume_or_init_state(
-            ckpt_path,
-            config,
-            rng_key,
-            initial_particles,
-            smc_alg,
-            fresh_extra={
-                "cov_scale": cov_scale,
-                "accept_history": [],
-                "cov_scale_history": [],
-            },
-            restore_extra=lambda ckpt: {
-                "cov_scale": float(ckpt.get("cov_scale", cov_scale)),
-                "accept_history": list(ckpt["accept_history"]),
-                "cov_scale_history": list(ckpt["cov_scale_history"]),
-            },
-        )
-        cov_scale = _extra["cov_scale"]
-        accept_list: list[float] = _extra["accept_history"]
-        cov_scale_list: list[float] = _extra["cov_scale_history"]
-
-        step_fn = jax.jit(smc_alg.step)
-        _last_ckpt_t = time.perf_counter()
-
-        while state.sampler_state.tempering_param < 1.0:  # type: ignore[attr-defined]  # blackjax stubs
-            rng_key, subkey = jax.random.split(rng_key)
-            state, info = step_fn(subkey, state)
-
-            ps = state.sampler_state
-            acceptance_rate = float(info.update_info.acceptance_rate.mean())
-            new_scale = cov_scale * float(
-                jnp.exp(
-                    config.scale_adaptation_gain
-                    * (acceptance_rate - config.target_acceptance_rate)
-                )
+        covariance_scale = float(config.grw.initial_cov_scale)
+        state, rng_key, n_completed_iterations, mode_checkpoint_data = (
+            self._load_or_initialize_state(
+                checkpoint_path,
+                config,
+                rng_key,
+                initial_particles,
+                smc_algorithm.init,
+                initial_mode_data={
+                    "cov_scale": covariance_scale,
+                    "accept_history": [],
+                    "cov_scale_history": [],
+                },
+                load_mode_data=lambda checkpoint: {
+                    "cov_scale": float(checkpoint.get("cov_scale", covariance_scale)),
+                    "accept_history": list(checkpoint["accept_history"]),
+                    "cov_scale_history": list(checkpoint["cov_scale_history"]),
+                },
             )
-            current_cov = state.parameter_override["cov"]
-            new_params = extend_params({"cov": current_cov[0] * new_scale})  # type: ignore[arg-type]  # blackjax stubs
-            state = StateWithParameterOverride(ps, new_params)  # type: ignore[arg-type]  # blackjax stubs
+        )
+        covariance_scale = mode_checkpoint_data["cov_scale"]
+        acceptance_history: list[float] = mode_checkpoint_data["accept_history"]
+        covariance_scale_history: list[float] = mode_checkpoint_data[
+            "cov_scale_history"
+        ]
 
-            accept_list.append(acceptance_rate)
-            cov_scale_list.append(new_scale)
-            cov_scale = new_scale
-            n_iter += 1
+        run_adaptive_step = jax.jit(smc_algorithm.step)
+        last_checkpoint_at = time.perf_counter()
 
-            if (
-                ckpt_path is not None
-                and config.checkpoint_interval > 0
-                and time.perf_counter() - _last_ckpt_t >= config.checkpoint_interval
-            ):
-                _last_ckpt_t = config.write_checkpoint(
-                    {
-                        "state": state,
-                        "rng_key": rng_key,
-                        "n_iter": n_iter,
-                        "mode": self.mode,
-                        "sampler_name": self.sampler_name,
-                        "elapsed_time": self._prev_elapsed
-                        + (time.perf_counter() - _method_t0),
-                        "cov_scale": cov_scale,
-                        "accept_history": accept_list.copy(),
-                        "cov_scale_history": cov_scale_list.copy(),
-                    },
-                    f"{self.sampler_name} ({self.mode.upper()})",
+        while state.sampler_state.tempering_param < 1.0:  # type: ignore[attr-defined]
+            rng_key, step_key = jax.random.split(rng_key)
+            state, info = run_adaptive_step(step_key, state)
+
+            acceptance_rate = float(info.update_info.acceptance_rate.mean())
+
+            if config.inner_kernel == "GRW":
+                sampler_state = state.sampler_state
+                updated_covariance_scale = covariance_scale * float(
+                    jnp.exp(
+                        config.grw.scale_adaptation_gain
+                        * (acceptance_rate - config.grw.target_acceptance_rate)
+                    )
                 )
+                current_covariance = state.parameter_override["cov"]
+                updated_parameters = extend_params(
+                    {"cov": current_covariance[0] * updated_covariance_scale}  # type: ignore[arg-type]
+                )
+                state = StateWithParameterOverride(sampler_state, updated_parameters)  # type: ignore[arg-type]
+                covariance_scale_history.append(updated_covariance_scale)
+                covariance_scale = updated_covariance_scale
+
+            acceptance_history.append(acceptance_rate)
+            n_completed_iterations += 1
+
+            last_checkpoint_at = self._save_checkpoint_if_due(
+                config,
+                checkpoint_path,
+                last_checkpoint_at,
+                run_started_at,
+                state,
+                rng_key,
+                n_completed_iterations,
+                {
+                    "cov_scale": covariance_scale,
+                    "accept_history": acceptance_history.copy(),
+                    "cov_scale_history": covariance_scale_history.copy(),
+                },
+            )
 
         self._final_state = state
-        self._n_iterations = n_iter
-        self._acceptance_history = np.asarray(accept_list)
-        self._cov_scale_history = np.asarray(cov_scale_list)
-        if ckpt_path is not None:
-            ckpt_path.unlink(missing_ok=True)
-        if config.checkpoint_dir is not None:
-            shutil.rmtree(config.checkpoint_dir / "jax_cache", ignore_errors=True)
-            jax.config.update("jax_compilation_cache_dir", None)
+        self._n_iterations = n_completed_iterations
+        self._acceptance_history = np.asarray(acceptance_history)
+        self._cov_scale_history = np.asarray(covariance_scale_history)
+        self._remove_checkpoint_and_jax_cache(config, checkpoint_path)
 
     def _run_fixed_persistent(
         self, rng_key: Key, initial_particles, ladder: list[float]
     ) -> None:
-        """Mode FP: persistent_sampling_smc over an explicit temperature ladder — Python for loop."""
+        """Run fixed-ladder persistent SMC with the configured inner kernel."""
         config = self._config
         n_mcmc_steps = config.n_mcmc_steps_per_dim * self.n_dims
-        ladder_values = ladder[1:]  # skip 0.0 (already in init state)
-        n_schedule = len(ladder_values)
-        ckpt_path = (
-            config.checkpoint_dir / "checkpoint.pkl"
-            if config.checkpoint_dir is not None
-            else None
-        )
-        config.configure_jax_cache()
-        _method_t0 = time.perf_counter()
+        tempering_parameters = ladder[1:]
+        n_temperature_steps = len(tempering_parameters)
+        checkpoint_path, run_started_at = self._prepare_checkpointing(config)
 
-        mcmc_step = self._build_mcmc_step()
-        cov0 = jnp.atleast_2d(jnp.cov(initial_particles.T)) * config.initial_cov_scale
-
-        smc_alg = persistent_sampling_smc(
-            logprior_fn=self._log_prior_fn,
-            loglikelihood_fn=self._log_likelihood_fn,
-            n_schedule=n_schedule,
-            mcmc_step_fn=mcmc_step,
-            mcmc_init_fn=rmh.init,
-            mcmc_parameters=extend_params({"cov": cov0}),  # type: ignore[arg-type]  # blackjax stubs: extend_params accepts dict
-            resampling_fn=systematic,
-            num_mcmc_steps=n_mcmc_steps,
-            batch_size=config.batch_size,
+        inner_kernel_step = self._build_inner_kernel_step()
+        initialize_state, temperature_step = self._build_fixed_ladder_smc(
+            uses_persistent_sampling=True,
+            inner_kernel_step=inner_kernel_step,
+            initial_particles=initial_particles,
+            n_temperature_steps=n_temperature_steps,
+            n_mcmc_steps=n_mcmc_steps,
         )
 
-        state, rng_key, n_iter, _extra = self._resume_or_init_state(
-            ckpt_path,
-            config,
-            rng_key,
-            initial_particles,
-            smc_alg,
-            fresh_extra={"accept_history": []},
-            restore_extra=lambda ckpt: {"accept_history": list(ckpt["accept_history"])},
-            n_schedule=n_schedule,
+        state, rng_key, n_completed_iterations, mode_checkpoint_data = (
+            self._load_or_initialize_state(
+                checkpoint_path,
+                config,
+                rng_key,
+                initial_particles,
+                initialize_state,
+                initial_mode_data={"accept_history": []},
+                load_mode_data=lambda checkpoint: {
+                    "accept_history": list(checkpoint["accept_history"])
+                },
+                n_temperature_steps=n_temperature_steps,
+            )
         )
-        accept_list: list[float] = _extra["accept_history"]
+        acceptance_history: list[float] = mode_checkpoint_data["accept_history"]
 
-        step_fn = jax.jit(smc_alg.step)
-        _last_ckpt_t = time.perf_counter()
+        run_temperature_step = jax.jit(temperature_step)
+        last_checkpoint_at = time.perf_counter()
 
-        for lmbda in ladder_values[n_iter:]:
-            rng_key, subkey = jax.random.split(rng_key)
-            state, info = step_fn(subkey, state, lmbda)
-            accept_list.append(float(info.update_info.acceptance_rate.mean()))
-            n_iter += 1
-            if (
-                ckpt_path is not None
-                and config.checkpoint_interval > 0
-                and time.perf_counter() - _last_ckpt_t >= config.checkpoint_interval
-            ):
-                _last_ckpt_t = config.write_checkpoint(
-                    {
-                        "state": state,
-                        "rng_key": rng_key,
-                        "n_iter": n_iter,
-                        "mode": self.mode,
-                        "sampler_name": self.sampler_name,
-                        "elapsed_time": self._prev_elapsed
-                        + (time.perf_counter() - _method_t0),
-                        "accept_history": accept_list.copy(),
-                    },
-                    f"{self.sampler_name} ({self.mode.upper()})",
-                )
+        for tempering_parameter in tempering_parameters[n_completed_iterations:]:
+            rng_key, step_key = jax.random.split(rng_key)
+            state, info = run_temperature_step(step_key, state, tempering_parameter)
+            acceptance_history.append(float(info.update_info.acceptance_rate.mean()))
+            n_completed_iterations += 1
+            last_checkpoint_at = self._save_checkpoint_if_due(
+                config,
+                checkpoint_path,
+                last_checkpoint_at,
+                run_started_at,
+                state,
+                rng_key,
+                n_completed_iterations,
+                {"accept_history": acceptance_history.copy()},
+            )
 
         self._final_state = state
-        self._n_iterations = n_schedule
-        self._acceptance_history = np.asarray(accept_list)
-        if ckpt_path is not None:
-            ckpt_path.unlink(missing_ok=True)
-        if config.checkpoint_dir is not None:
-            shutil.rmtree(config.checkpoint_dir / "jax_cache", ignore_errors=True)
-            jax.config.update("jax_compilation_cache_dir", None)
+        self._n_iterations = n_temperature_steps
+        self._acceptance_history = np.asarray(acceptance_history)
+        self._remove_checkpoint_and_jax_cache(config, checkpoint_path)
 
     def _run_adaptive_tempered(self, rng_key: Key, initial_particles) -> None:
-        """Mode AT: adaptive_tempered_smc + inner_kernel_tuning + Python while."""
+        """Run adaptive tempered SMC with the configured inner kernel."""
         config = self._config
         n_mcmc_steps = config.n_mcmc_steps_per_dim * self.n_dims
         target_ess = config._resolve_target_ess_fraction()
-        ckpt_path = (
-            config.checkpoint_dir / "checkpoint.pkl"
-            if config.checkpoint_dir is not None
-            else None
+        checkpoint_path, run_started_at = self._prepare_checkpointing(config)
+
+        inner_kernel_step = self._build_inner_kernel_step()
+        update_mcmc_parameters, initial_mcmc_parameters = (
+            self._build_adaptive_inner_kernel_parameters(initial_particles)
         )
-        config.configure_jax_cache()
-        _method_t0 = time.perf_counter()
 
-        mcmc_step = self._build_mcmc_step()
-        cov0 = jnp.atleast_2d(jnp.cov(initial_particles.T)) * config.initial_cov_scale
-
-        def mcmc_parameter_update_fn(_key, state, _info):
-            return extend_params({"cov": jnp.atleast_2d(jnp.cov(state.particles.T))})  # type: ignore[arg-type]  # blackjax stubs: extend_params accepts dict
-
-        smc_alg = inner_kernel_tuning(
+        smc_algorithm = inner_kernel_tuning(
             smc_algorithm=adaptive_tempered_smc,
             logprior_fn=self._log_prior_fn,
             loglikelihood_fn=self._log_likelihood_fn,
-            mcmc_step_fn=mcmc_step,
+            mcmc_step_fn=inner_kernel_step,
             mcmc_init_fn=rmh.init,
             resampling_fn=systematic,
-            mcmc_parameter_update_fn=mcmc_parameter_update_fn,
-            initial_parameter_value=extend_params({"cov": cov0}),  # type: ignore[arg-type]  # blackjax stubs: extend_params accepts dict
+            mcmc_parameter_update_fn=update_mcmc_parameters,
+            initial_parameter_value=initial_mcmc_parameters,
             num_mcmc_steps=n_mcmc_steps,
             target_ess=target_ess,
             batch_size=config.batch_size,
         )
 
-        state, rng_key, n_iter, _extra = self._resume_or_init_state(
-            ckpt_path,
-            config,
-            rng_key,
-            initial_particles,
-            smc_alg,
-            fresh_extra={
-                "accept_history": [],
-                "tempering_schedule": [],
-                "is_weights_history": [],
-            },
-            restore_extra=lambda ckpt: {
-                "accept_history": list(ckpt["accept_history"]),
-                "tempering_schedule": list(ckpt["tempering_schedule"]),
-                "is_weights_history": list(ckpt["is_weights_history"]),
-            },
+        state, rng_key, n_completed_iterations, mode_checkpoint_data = (
+            self._load_or_initialize_state(
+                checkpoint_path,
+                config,
+                rng_key,
+                initial_particles,
+                smc_algorithm.init,
+                initial_mode_data={
+                    "accept_history": [],
+                    "tempering_schedule": [],
+                    "is_weights_history": [],
+                },
+                load_mode_data=lambda checkpoint: {
+                    "accept_history": list(checkpoint["accept_history"]),
+                    "tempering_schedule": list(checkpoint["tempering_schedule"]),
+                    "is_weights_history": list(checkpoint["is_weights_history"]),
+                },
+            )
         )
-        accept_list: list[float] = _extra["accept_history"]
-        temp_list: list[float] = _extra["tempering_schedule"]
-        is_weights_list: list[np.ndarray] = _extra["is_weights_history"]
+        acceptance_history: list[float] = mode_checkpoint_data["accept_history"]
+        tempering_schedule: list[float] = mode_checkpoint_data["tempering_schedule"]
+        importance_weight_history: list[np.ndarray] = mode_checkpoint_data[
+            "is_weights_history"
+        ]
 
-        step_fn = jax.jit(smc_alg.step)
-        _last_ckpt_t = time.perf_counter()
+        run_adaptive_step = jax.jit(smc_algorithm.step)
+        last_checkpoint_at = time.perf_counter()
 
         while state.sampler_state.tempering_param < 1.0:
-            rng_key, subkey = jax.random.split(rng_key)
-            state, info = step_fn(subkey, state)
+            rng_key, step_key = jax.random.split(rng_key)
+            state, info = run_adaptive_step(step_key, state)
 
-            accept_list.append(float(info.update_info.acceptance_rate.mean()))
-            temp_list.append(float(state.sampler_state.tempering_param))
-            is_weights_list.append(np.asarray(state.sampler_state.weights))
-            n_iter += 1
+            acceptance_history.append(float(info.update_info.acceptance_rate.mean()))
+            tempering_schedule.append(float(state.sampler_state.tempering_param))
+            importance_weight_history.append(np.asarray(state.sampler_state.weights))
+            n_completed_iterations += 1
 
-            if (
-                ckpt_path is not None
-                and config.checkpoint_interval > 0
-                and time.perf_counter() - _last_ckpt_t >= config.checkpoint_interval
-            ):
-                _last_ckpt_t = config.write_checkpoint(
-                    {
-                        "state": state,
-                        "rng_key": rng_key,
-                        "n_iter": n_iter,
-                        "mode": self.mode,
-                        "sampler_name": self.sampler_name,
-                        "elapsed_time": self._prev_elapsed
-                        + (time.perf_counter() - _method_t0),
-                        "accept_history": accept_list.copy(),
-                        "tempering_schedule": temp_list.copy(),
-                        "is_weights_history": np.stack(is_weights_list),
-                    },
-                    f"{self.sampler_name} ({self.mode.upper()})",
-                )
+            last_checkpoint_at = self._save_checkpoint_if_due(
+                config,
+                checkpoint_path,
+                last_checkpoint_at,
+                run_started_at,
+                state,
+                rng_key,
+                n_completed_iterations,
+                {
+                    "accept_history": acceptance_history.copy(),
+                    "tempering_schedule": tempering_schedule.copy(),
+                    "is_weights_history": np.stack(importance_weight_history),
+                },
+            )
 
         self._final_state = state
-        self._n_iterations = n_iter
-        self._acceptance_history = np.asarray(accept_list)
-        self._tempering_schedule = np.asarray(temp_list)
+        self._n_iterations = n_completed_iterations
+        self._acceptance_history = np.asarray(acceptance_history)
+        self._tempering_schedule = np.asarray(tempering_schedule)
         self._is_weights_history = (
-            np.stack(is_weights_list)
-            if is_weights_list
+            np.stack(importance_weight_history)
+            if importance_weight_history
             else np.empty((0, initial_particles.shape[0]))
         )
-        if ckpt_path is not None:
-            ckpt_path.unlink(missing_ok=True)
-        if config.checkpoint_dir is not None:
-            shutil.rmtree(config.checkpoint_dir / "jax_cache", ignore_errors=True)
-            jax.config.update("jax_compilation_cache_dir", None)
+        self._remove_checkpoint_and_jax_cache(config, checkpoint_path)
 
     def _run_fixed_tempered(
         self, rng_key: Key, initial_particles, ladder: list[float]
     ) -> None:
-        """Mode FT: tempered_smc + Python for loop over explicit temperature ladder."""
+        """Run fixed-ladder tempered SMC with the configured inner kernel."""
         config = self._config
         n_mcmc_steps = config.n_mcmc_steps_per_dim * self.n_dims
-        ladder_values = ladder[1:]  # skip 0.0
-        n_schedule = len(ladder_values)
-        ckpt_path = (
-            config.checkpoint_dir / "checkpoint.pkl"
-            if config.checkpoint_dir is not None
-            else None
-        )
-        config.configure_jax_cache()
-        _method_t0 = time.perf_counter()
+        tempering_parameters = ladder[1:]
+        n_temperature_steps = len(tempering_parameters)
+        checkpoint_path, run_started_at = self._prepare_checkpointing(config)
 
-        mcmc_step = self._build_mcmc_step()
-        cov0 = jnp.atleast_2d(jnp.cov(initial_particles.T)) * config.initial_cov_scale
-
-        smc_alg = tempered_smc(
-            logprior_fn=self._log_prior_fn,
-            loglikelihood_fn=self._log_likelihood_fn,
-            mcmc_step_fn=mcmc_step,
-            mcmc_init_fn=rmh.init,
-            mcmc_parameters=extend_params({"cov": cov0}),  # type: ignore[arg-type]  # blackjax stubs: extend_params accepts dict
-            resampling_fn=systematic,
-            num_mcmc_steps=n_mcmc_steps,
-            batch_size=config.batch_size,
+        inner_kernel_step = self._build_inner_kernel_step()
+        initialize_state, temperature_step = self._build_fixed_ladder_smc(
+            uses_persistent_sampling=False,
+            inner_kernel_step=inner_kernel_step,
+            initial_particles=initial_particles,
+            n_temperature_steps=n_temperature_steps,
+            n_mcmc_steps=n_mcmc_steps,
         )
 
-        state, rng_key, n_iter, _extra = self._resume_or_init_state(
-            ckpt_path,
-            config,
-            rng_key,
-            initial_particles,
-            smc_alg,
-            fresh_extra={"accept_history": [], "is_weights_history": []},
-            restore_extra=lambda ckpt: {
-                "accept_history": list(ckpt["accept_history"]),
-                "is_weights_history": list(ckpt["is_weights_history"]),
-            },
-            n_schedule=n_schedule,
+        state, rng_key, n_completed_iterations, mode_checkpoint_data = (
+            self._load_or_initialize_state(
+                checkpoint_path,
+                config,
+                rng_key,
+                initial_particles,
+                initialize_state,
+                initial_mode_data={"accept_history": [], "is_weights_history": []},
+                load_mode_data=lambda checkpoint: {
+                    "accept_history": list(checkpoint["accept_history"]),
+                    "is_weights_history": list(checkpoint["is_weights_history"]),
+                },
+                n_temperature_steps=n_temperature_steps,
+            )
         )
-        accept_list: list[float] = _extra["accept_history"]
-        is_weights_list: list[np.ndarray] = _extra["is_weights_history"]
+        acceptance_history: list[float] = mode_checkpoint_data["accept_history"]
+        importance_weight_history: list[np.ndarray] = mode_checkpoint_data[
+            "is_weights_history"
+        ]
 
-        step_fn = jax.jit(smc_alg.step)
-        _last_ckpt_t = time.perf_counter()
+        run_temperature_step = jax.jit(temperature_step)
+        last_checkpoint_at = time.perf_counter()
 
-        for lmbda in ladder_values[n_iter:]:
-            rng_key, subkey = jax.random.split(rng_key)
-            state, info = step_fn(subkey, state, lmbda)
-            accept_list.append(float(info.update_info.acceptance_rate.mean()))
-            is_weights_list.append(np.asarray(state.weights))
-            n_iter += 1
-            if (
-                ckpt_path is not None
-                and config.checkpoint_interval > 0
-                and time.perf_counter() - _last_ckpt_t >= config.checkpoint_interval
-            ):
-                _last_ckpt_t = config.write_checkpoint(
-                    {
-                        "state": state,
-                        "rng_key": rng_key,
-                        "n_iter": n_iter,
-                        "mode": self.mode,
-                        "sampler_name": self.sampler_name,
-                        "elapsed_time": self._prev_elapsed
-                        + (time.perf_counter() - _method_t0),
-                        "accept_history": accept_list.copy(),
-                        "is_weights_history": np.stack(is_weights_list),
-                    },
-                    f"{self.sampler_name} ({self.mode.upper()})",
-                )
+        for tempering_parameter in tempering_parameters[n_completed_iterations:]:
+            rng_key, step_key = jax.random.split(rng_key)
+            state, info = run_temperature_step(step_key, state, tempering_parameter)
+            acceptance_history.append(float(info.update_info.acceptance_rate.mean()))
+            importance_weight_history.append(np.asarray(state.weights))
+            n_completed_iterations += 1
+            last_checkpoint_at = self._save_checkpoint_if_due(
+                config,
+                checkpoint_path,
+                last_checkpoint_at,
+                run_started_at,
+                state,
+                rng_key,
+                n_completed_iterations,
+                {
+                    "accept_history": acceptance_history.copy(),
+                    "is_weights_history": np.stack(importance_weight_history),
+                },
+            )
 
         self._final_state = state
-        self._n_iterations = n_schedule
-        self._acceptance_history = np.asarray(accept_list)
+        self._n_iterations = n_temperature_steps
+        self._acceptance_history = np.asarray(acceptance_history)
         self._is_weights_history = (
-            np.stack(is_weights_list)
-            if is_weights_list
+            np.stack(importance_weight_history)
+            if importance_weight_history
             else np.empty((0, initial_particles.shape[0]))
         )
-        if ckpt_path is not None:
-            ckpt_path.unlink(missing_ok=True)
-        if config.checkpoint_dir is not None:
-            shutil.rmtree(config.checkpoint_dir / "jax_cache", ignore_errors=True)
-            jax.config.update("jax_compilation_cache_dir", None)
-
-    # ------------------------------------------------------------------
-    # Public API
-    # ------------------------------------------------------------------
+        self._remove_checkpoint_and_jax_cache(config, checkpoint_path)
 
     def _sample(
         self,
@@ -764,7 +897,8 @@ class BlackJAXSMCSampler(Sampler):
         * ``"acceptance_history"`` — per-iteration mean acceptance rate; length ``n_iterations``.
         * ``"n_iterations"`` — total SMC iterations (adaptive modes only).
         * ``"tempering_schedule"`` — inverse temperature at each iteration; length ``n_iterations`` (adaptive modes only).
-        * ``"cov_scale_history"`` — covariance scale per iteration (adaptive-persistent only); length ``n_iterations``.
+        * ``"cov_scale_history"`` — covariance scale per iteration for
+          adaptive-persistent GRW; empty for adaptive-persistent DE.
         * ``"ess_history"`` — ESS per iteration (all modes: persistent ESS for ap/fp, Kish ESS for at/ft); length ``n_iterations``.
         * ``"persistent_log_Z"`` — cumulative log-Z after each iteration; length ``n_iterations`` (persistent modes only).
         * ``"log_Z"`` — final log Bayesian evidence (persistent modes only).

--- a/src/jimgw/samplers/blackjax/smc.py
+++ b/src/jimgw/samplers/blackjax/smc.py
@@ -9,12 +9,8 @@ Supports four mode combinations selected by
 * ``persistent_sampling=False, temperature_ladder=given`` → fixed-ladder tempered SMC
 """
 
-import logging
-import pickle
-import shutil
 import time
 from collections.abc import Callable
-from pathlib import Path
 from typing import Any, Optional
 
 import jax
@@ -44,10 +40,18 @@ from jimgw.samplers.blackjax._de_move import (
     sample_de_gamma,
     sample_two_distinct_indices,
 )
+from jimgw.samplers.blackjax.smc_utils import (
+    checkpoint_safe_state,
+    restore_checkpoint_ensemble,
+)
+from jimgw.samplers.blackjax.utils import (
+    load_or_initialize_checkpoint,
+    prepare_checkpointing,
+    remove_checkpoint_and_jax_cache,
+    save_checkpoint_if_due,
+)
 from jimgw.samplers.config import BlackJAXSMCConfig
 from jimgw.samplers.periodic import to_displacement_wrapper
-
-logger = logging.getLogger(__name__)
 
 # Fixed key used for post-sampling resampling in get_samples().
 _RESAMPLE_KEY = jax.random.key(123)
@@ -294,202 +298,12 @@ class BlackJAXSMCSampler(Sampler):
         )
         return smc_algorithm.init, smc_algorithm.step
 
-    def _checkpoint_safe_state(self, config: BlackJAXSMCConfig, state: Any) -> Any:
-        """Drop the DE reference ensemble from ``state`` before checkpointing.
-
-        For ``inner_kernel="DE"`` in the adaptive (inner-kernel-tuning) modes,
-        ``state.parameter_override["ensemble"]`` is always an exact copy of
-        ``state.sampler_state.particles`` — see
-        ``_build_adaptive_inner_kernel_parameters``'s ``update_ensemble_parameters``,
-        which sets it to ``extend_params({"ensemble": smc_state.particles})`` every
-        step. Persisting it doubles the particle population's footprint in every
-        checkpoint file for no benefit, since ``_restore_checkpoint_ensemble``
-        recomputes it from ``sampler_state.particles`` on resume.
-        """
-        if config.inner_kernel == "DE" and isinstance(
-            state, StateWithParameterOverride
-        ):
-            return state._replace(
-                parameter_override={
-                    key: value
-                    for key, value in state.parameter_override.items()
-                    if key != "ensemble"
-                }
-            )
-        return state
-
-    def _restore_checkpoint_ensemble(
-        self, config: BlackJAXSMCConfig, state: Any
-    ) -> Any:
-        """Reconstruct the DE ensemble dropped by ``_checkpoint_safe_state``."""
-        if (
-            config.inner_kernel == "DE"
-            and isinstance(state, StateWithParameterOverride)
-            and "ensemble" not in state.parameter_override
-        ):
-            return state._replace(
-                parameter_override={
-                    **state.parameter_override,
-                    **extend_params(
-                        {"ensemble": state.sampler_state.particles}  # type: ignore[arg-type]
-                    ),
-                }
-            )
-        return state
-
-    def _load_or_initialize_state(
-        self,
-        checkpoint_path: Optional[Path],
-        config: BlackJAXSMCConfig,
-        rng_key: Key,
-        initial_particles,
-        initialize_state: Callable,
-        initial_mode_data: dict[str, Any],
-        load_mode_data: Callable[[dict], dict[str, Any]],
-        n_temperature_steps: Optional[int] = None,
-    ) -> tuple[Any, Key, int, dict[str, Any]]:
-        """Load a compatible checkpoint or initialize a new SMC state.
-
-        ``load_mode_data`` restores histories that are specific to each SMC
-        mode. ``initial_mode_data`` is used when no usable checkpoint exists or
-        when a fixed-ladder checkpoint exceeds the current number of temperature
-        steps. Only trusted checkpoint files may be loaded because pickle can
-        execute arbitrary code.
-        """
-        if not (
-            checkpoint_path is not None
-            and config.checkpoint_interval > 0
-            and checkpoint_path.exists()
-        ):
-            self._prev_elapsed = 0.0
-            return (
-                initialize_state(initial_particles),
-                rng_key,
-                0,
-                dict(initial_mode_data),
-            )
-
-        initial_rng_key = rng_key
-        try:
-            with open(checkpoint_path, "rb") as checkpoint_file:
-                checkpoint = pickle.load(checkpoint_file)
-            self._validate_checkpoint(checkpoint)
-            state = checkpoint["state"]
-            rng_key = checkpoint["rng_key"]
-            n_completed_iterations = checkpoint["n_iter"]
-            mode_data = load_mode_data(checkpoint)
-            if (
-                n_temperature_steps is not None
-                and n_completed_iterations > n_temperature_steps
-            ):
-                logger.warning(
-                    "%s: checkpoint n_iter=%d exceeds current schedule length=%d — starting fresh.",
-                    f"{self.sampler_name} ({self.mode.upper()})",
-                    n_completed_iterations,
-                    n_temperature_steps,
-                )
-                rng_key = initial_rng_key
-                state = initialize_state(initial_particles)
-                n_completed_iterations = 0
-                mode_data = dict(initial_mode_data)
-                self._prev_elapsed = 0.0
-            else:
-                self._prev_elapsed = float(checkpoint["elapsed_time"])
-                state = self._restore_checkpoint_ensemble(config, state)
-                logger.info(
-                    "%s: resumed from checkpoint at n_iter=%d (%s)",
-                    f"{self.sampler_name} ({self.mode.upper()})",
-                    n_completed_iterations,
-                    checkpoint_path,
-                )
-            return state, rng_key, n_completed_iterations, mode_data
-        except (
-            OSError,
-            EOFError,
-            KeyError,
-            TypeError,
-            ValueError,
-            pickle.UnpicklingError,
-        ) as error:
-            logger.warning(
-                "%s: incompatible or corrupt checkpoint at %s (%s) — starting fresh.",
-                f"{self.sampler_name} ({self.mode.upper()})",
-                checkpoint_path,
-                error,
-            )
-            self._prev_elapsed = 0.0
-            return (
-                initialize_state(initial_particles),
-                initial_rng_key,
-                0,
-                dict(initial_mode_data),
-            )
-
-    def _prepare_checkpointing(
-        self, config: BlackJAXSMCConfig
-    ) -> tuple[Optional[Path], float]:
-        """Enable the JAX compile cache and return the checkpoint path and start time."""
-        checkpoint_path = (
-            config.checkpoint_dir / "checkpoint.pkl"
-            if config.checkpoint_dir is not None
-            else None
-        )
-        config.configure_jax_cache()
-        return checkpoint_path, time.perf_counter()
-
-    def _save_checkpoint_if_due(
-        self,
-        config: BlackJAXSMCConfig,
-        checkpoint_path: Optional[Path],
-        last_checkpoint_at: float,
-        run_started_at: float,
-        state: Any,
-        rng_key: Key,
-        n_completed_iterations: int,
-        mode_data: dict[str, Any],
-    ) -> float:
-        """Save a checkpoint when its interval has elapsed.
-
-        ``mode_data`` contains mode-specific histories to merge into the common
-        checkpoint data. Returns the last checkpoint time.
-        """
-        if not (
-            checkpoint_path is not None
-            and config.checkpoint_interval > 0
-            and time.perf_counter() - last_checkpoint_at >= config.checkpoint_interval
-        ):
-            return last_checkpoint_at
-        return config.write_checkpoint(
-            {
-                "state": self._checkpoint_safe_state(config, state),
-                "rng_key": rng_key,
-                "n_iter": n_completed_iterations,
-                "mode": self.mode,
-                "inner_kernel": config.inner_kernel,
-                "sampler_name": self.sampler_name,
-                "elapsed_time": self._prev_elapsed
-                + (time.perf_counter() - run_started_at),
-                **mode_data,
-            },
-            f"{self.sampler_name} ({self.mode.upper()})",
-        )
-
-    def _remove_checkpoint_and_jax_cache(
-        self, config: BlackJAXSMCConfig, checkpoint_path: Optional[Path]
-    ) -> None:
-        """Remove a completed run's checkpoint, JAX cache, and cache setting."""
-        if checkpoint_path is not None:
-            checkpoint_path.unlink(missing_ok=True)
-        if config.checkpoint_dir is not None:
-            shutil.rmtree(config.checkpoint_dir / "jax_cache", ignore_errors=True)
-            jax.config.update("jax_compilation_cache_dir", None)
-
     def _run_adaptive_persistent(self, rng_key: Key, initial_particles) -> None:
         """Run adaptive persistent SMC with the configured inner kernel."""
         config = self._config
         n_mcmc_steps = config.n_mcmc_steps_per_dim * self.n_dims
         target_ess = config._resolve_target_ess_fraction()
-        checkpoint_path, run_started_at = self._prepare_checkpointing(config)
+        checkpoint_path, run_start_time = prepare_checkpointing(config)
 
         inner_kernel_step = self._build_inner_kernel_step()
         update_mcmc_parameters, initial_mcmc_parameters = (
@@ -511,24 +325,28 @@ class BlackJAXSMCSampler(Sampler):
             batch_size=config.batch_size,
         )
 
+        log_label = f"{self.sampler_name} ({self.mode.upper()})"
         covariance_scale = float(config.grw.initial_cov_scale)
         state, rng_key, n_completed_iterations, mode_checkpoint_data = (
-            self._load_or_initialize_state(
+            load_or_initialize_checkpoint(
+                self,
                 checkpoint_path,
                 config,
                 rng_key,
                 initial_particles,
                 smc_algorithm.init,
-                initial_mode_data={
+                initial_extra={
                     "cov_scale": covariance_scale,
                     "accept_history": [],
                     "cov_scale_history": [],
                 },
-                load_mode_data=lambda checkpoint: {
+                load_extra=lambda checkpoint: {
                     "cov_scale": float(checkpoint.get("cov_scale", covariance_scale)),
                     "accept_history": list(checkpoint["accept_history"]),
                     "cov_scale_history": list(checkpoint["cov_scale_history"]),
                 },
+                log_label=log_label,
+                after_load=lambda state: restore_checkpoint_ensemble(config, state),
             )
         )
         covariance_scale = mode_checkpoint_data["cov_scale"]
@@ -538,7 +356,7 @@ class BlackJAXSMCSampler(Sampler):
         ]
 
         run_adaptive_step = jax.jit(smc_algorithm.step)
-        last_checkpoint_at = time.perf_counter()
+        last_checkpoint_write_time = time.perf_counter()
 
         while state.sampler_state.tempering_param < 1.0:  # type: ignore[attr-defined]
             rng_key, step_key = jax.random.split(rng_key)
@@ -565,26 +383,35 @@ class BlackJAXSMCSampler(Sampler):
             acceptance_history.append(acceptance_rate)
             n_completed_iterations += 1
 
-            last_checkpoint_at = self._save_checkpoint_if_due(
+            last_checkpoint_write_time = save_checkpoint_if_due(
+                self,
                 config,
                 checkpoint_path,
-                last_checkpoint_at,
-                run_started_at,
+                last_checkpoint_write_time,
+                run_start_time,
                 state,
                 rng_key,
                 n_completed_iterations,
                 {
+                    "mode": self.mode,
+                    "inner_kernel": config.inner_kernel,
                     "cov_scale": covariance_scale,
                     "accept_history": acceptance_history.copy(),
                     "cov_scale_history": covariance_scale_history.copy(),
                 },
+                log_label=log_label,
+                before_save=lambda state, rng_key, extra: (
+                    checkpoint_safe_state(config, state),
+                    rng_key,
+                    extra,
+                ),
             )
 
         self._final_state = state
         self._n_iterations = n_completed_iterations
         self._acceptance_history = np.asarray(acceptance_history)
         self._cov_scale_history = np.asarray(covariance_scale_history)
-        self._remove_checkpoint_and_jax_cache(config, checkpoint_path)
+        remove_checkpoint_and_jax_cache(config, checkpoint_path)
 
     def _run_fixed_persistent(
         self, rng_key: Key, initial_particles, ladder: list[float]
@@ -594,7 +421,8 @@ class BlackJAXSMCSampler(Sampler):
         n_mcmc_steps = config.n_mcmc_steps_per_dim * self.n_dims
         tempering_parameters = ladder[1:]
         n_temperature_steps = len(tempering_parameters)
-        checkpoint_path, run_started_at = self._prepare_checkpointing(config)
+        checkpoint_path, run_start_time = prepare_checkpointing(config)
+        log_label = f"{self.sampler_name} ({self.mode.upper()})"
 
         inner_kernel_step = self._build_inner_kernel_step()
         initialize_state, temperature_step = self._build_fixed_ladder_smc(
@@ -606,51 +434,68 @@ class BlackJAXSMCSampler(Sampler):
         )
 
         state, rng_key, n_completed_iterations, mode_checkpoint_data = (
-            self._load_or_initialize_state(
+            load_or_initialize_checkpoint(
+                self,
                 checkpoint_path,
                 config,
                 rng_key,
                 initial_particles,
                 initialize_state,
-                initial_mode_data={"accept_history": []},
-                load_mode_data=lambda checkpoint: {
+                initial_extra={"accept_history": []},
+                load_extra=lambda checkpoint: {
                     "accept_history": list(checkpoint["accept_history"])
                 },
-                n_temperature_steps=n_temperature_steps,
+                log_label=log_label,
+                after_load=lambda state: restore_checkpoint_ensemble(config, state),
+                is_stale=lambda n_iter: n_iter > n_temperature_steps,
+                stale_message="checkpoint n_iter exceeds current schedule length"
+                f"={n_temperature_steps}",
             )
         )
         acceptance_history: list[float] = mode_checkpoint_data["accept_history"]
 
         run_temperature_step = jax.jit(temperature_step)
-        last_checkpoint_at = time.perf_counter()
+        last_checkpoint_write_time = time.perf_counter()
 
         for tempering_parameter in tempering_parameters[n_completed_iterations:]:
             rng_key, step_key = jax.random.split(rng_key)
             state, info = run_temperature_step(step_key, state, tempering_parameter)
             acceptance_history.append(float(info.update_info.acceptance_rate.mean()))
             n_completed_iterations += 1
-            last_checkpoint_at = self._save_checkpoint_if_due(
+            last_checkpoint_write_time = save_checkpoint_if_due(
+                self,
                 config,
                 checkpoint_path,
-                last_checkpoint_at,
-                run_started_at,
+                last_checkpoint_write_time,
+                run_start_time,
                 state,
                 rng_key,
                 n_completed_iterations,
-                {"accept_history": acceptance_history.copy()},
+                {
+                    "mode": self.mode,
+                    "inner_kernel": config.inner_kernel,
+                    "accept_history": acceptance_history.copy(),
+                },
+                log_label=log_label,
+                before_save=lambda state, rng_key, extra: (
+                    checkpoint_safe_state(config, state),
+                    rng_key,
+                    extra,
+                ),
             )
 
         self._final_state = state
         self._n_iterations = n_temperature_steps
         self._acceptance_history = np.asarray(acceptance_history)
-        self._remove_checkpoint_and_jax_cache(config, checkpoint_path)
+        remove_checkpoint_and_jax_cache(config, checkpoint_path)
 
     def _run_adaptive_tempered(self, rng_key: Key, initial_particles) -> None:
         """Run adaptive tempered SMC with the configured inner kernel."""
         config = self._config
         n_mcmc_steps = config.n_mcmc_steps_per_dim * self.n_dims
         target_ess = config._resolve_target_ess_fraction()
-        checkpoint_path, run_started_at = self._prepare_checkpointing(config)
+        checkpoint_path, run_start_time = prepare_checkpointing(config)
+        log_label = f"{self.sampler_name} ({self.mode.upper()})"
 
         inner_kernel_step = self._build_inner_kernel_step()
         update_mcmc_parameters, initial_mcmc_parameters = (
@@ -672,22 +517,25 @@ class BlackJAXSMCSampler(Sampler):
         )
 
         state, rng_key, n_completed_iterations, mode_checkpoint_data = (
-            self._load_or_initialize_state(
+            load_or_initialize_checkpoint(
+                self,
                 checkpoint_path,
                 config,
                 rng_key,
                 initial_particles,
                 smc_algorithm.init,
-                initial_mode_data={
+                initial_extra={
                     "accept_history": [],
                     "tempering_schedule": [],
                     "is_weights_history": [],
                 },
-                load_mode_data=lambda checkpoint: {
+                load_extra=lambda checkpoint: {
                     "accept_history": list(checkpoint["accept_history"]),
                     "tempering_schedule": list(checkpoint["tempering_schedule"]),
                     "is_weights_history": list(checkpoint["is_weights_history"]),
                 },
+                log_label=log_label,
+                after_load=lambda state: restore_checkpoint_ensemble(config, state),
             )
         )
         acceptance_history: list[float] = mode_checkpoint_data["accept_history"]
@@ -697,7 +545,7 @@ class BlackJAXSMCSampler(Sampler):
         ]
 
         run_adaptive_step = jax.jit(smc_algorithm.step)
-        last_checkpoint_at = time.perf_counter()
+        last_checkpoint_write_time = time.perf_counter()
 
         while state.sampler_state.tempering_param < 1.0:
             rng_key, step_key = jax.random.split(rng_key)
@@ -708,19 +556,28 @@ class BlackJAXSMCSampler(Sampler):
             importance_weight_history.append(np.asarray(state.sampler_state.weights))
             n_completed_iterations += 1
 
-            last_checkpoint_at = self._save_checkpoint_if_due(
+            last_checkpoint_write_time = save_checkpoint_if_due(
+                self,
                 config,
                 checkpoint_path,
-                last_checkpoint_at,
-                run_started_at,
+                last_checkpoint_write_time,
+                run_start_time,
                 state,
                 rng_key,
                 n_completed_iterations,
                 {
+                    "mode": self.mode,
+                    "inner_kernel": config.inner_kernel,
                     "accept_history": acceptance_history.copy(),
                     "tempering_schedule": tempering_schedule.copy(),
                     "is_weights_history": np.stack(importance_weight_history),
                 },
+                log_label=log_label,
+                before_save=lambda state, rng_key, extra: (
+                    checkpoint_safe_state(config, state),
+                    rng_key,
+                    extra,
+                ),
             )
 
         self._final_state = state
@@ -732,7 +589,7 @@ class BlackJAXSMCSampler(Sampler):
             if importance_weight_history
             else np.empty((0, initial_particles.shape[0]))
         )
-        self._remove_checkpoint_and_jax_cache(config, checkpoint_path)
+        remove_checkpoint_and_jax_cache(config, checkpoint_path)
 
     def _run_fixed_tempered(
         self, rng_key: Key, initial_particles, ladder: list[float]
@@ -742,7 +599,8 @@ class BlackJAXSMCSampler(Sampler):
         n_mcmc_steps = config.n_mcmc_steps_per_dim * self.n_dims
         tempering_parameters = ladder[1:]
         n_temperature_steps = len(tempering_parameters)
-        checkpoint_path, run_started_at = self._prepare_checkpointing(config)
+        checkpoint_path, run_start_time = prepare_checkpointing(config)
+        log_label = f"{self.sampler_name} ({self.mode.upper()})"
 
         inner_kernel_step = self._build_inner_kernel_step()
         initialize_state, temperature_step = self._build_fixed_ladder_smc(
@@ -754,18 +612,23 @@ class BlackJAXSMCSampler(Sampler):
         )
 
         state, rng_key, n_completed_iterations, mode_checkpoint_data = (
-            self._load_or_initialize_state(
+            load_or_initialize_checkpoint(
+                self,
                 checkpoint_path,
                 config,
                 rng_key,
                 initial_particles,
                 initialize_state,
-                initial_mode_data={"accept_history": [], "is_weights_history": []},
-                load_mode_data=lambda checkpoint: {
+                initial_extra={"accept_history": [], "is_weights_history": []},
+                load_extra=lambda checkpoint: {
                     "accept_history": list(checkpoint["accept_history"]),
                     "is_weights_history": list(checkpoint["is_weights_history"]),
                 },
-                n_temperature_steps=n_temperature_steps,
+                log_label=log_label,
+                after_load=lambda state: restore_checkpoint_ensemble(config, state),
+                is_stale=lambda n_iter: n_iter > n_temperature_steps,
+                stale_message="checkpoint n_iter exceeds current schedule length"
+                f"={n_temperature_steps}",
             )
         )
         acceptance_history: list[float] = mode_checkpoint_data["accept_history"]
@@ -774,7 +637,7 @@ class BlackJAXSMCSampler(Sampler):
         ]
 
         run_temperature_step = jax.jit(temperature_step)
-        last_checkpoint_at = time.perf_counter()
+        last_checkpoint_write_time = time.perf_counter()
 
         for tempering_parameter in tempering_parameters[n_completed_iterations:]:
             rng_key, step_key = jax.random.split(rng_key)
@@ -782,18 +645,27 @@ class BlackJAXSMCSampler(Sampler):
             acceptance_history.append(float(info.update_info.acceptance_rate.mean()))
             importance_weight_history.append(np.asarray(state.weights))
             n_completed_iterations += 1
-            last_checkpoint_at = self._save_checkpoint_if_due(
+            last_checkpoint_write_time = save_checkpoint_if_due(
+                self,
                 config,
                 checkpoint_path,
-                last_checkpoint_at,
-                run_started_at,
+                last_checkpoint_write_time,
+                run_start_time,
                 state,
                 rng_key,
                 n_completed_iterations,
                 {
+                    "mode": self.mode,
+                    "inner_kernel": config.inner_kernel,
                     "accept_history": acceptance_history.copy(),
                     "is_weights_history": np.stack(importance_weight_history),
                 },
+                log_label=log_label,
+                before_save=lambda state, rng_key, extra: (
+                    checkpoint_safe_state(config, state),
+                    rng_key,
+                    extra,
+                ),
             )
 
         self._final_state = state
@@ -804,7 +676,7 @@ class BlackJAXSMCSampler(Sampler):
             if importance_weight_history
             else np.empty((0, initial_particles.shape[0]))
         )
-        self._remove_checkpoint_and_jax_cache(config, checkpoint_path)
+        remove_checkpoint_and_jax_cache(config, checkpoint_path)
 
     def _sample(
         self,

--- a/src/jimgw/samplers/blackjax/smc.py
+++ b/src/jimgw/samplers/blackjax/smc.py
@@ -294,6 +294,49 @@ class BlackJAXSMCSampler(Sampler):
         )
         return smc_algorithm.init, smc_algorithm.step
 
+    def _checkpoint_safe_state(self, config: BlackJAXSMCConfig, state: Any) -> Any:
+        """Drop the DE reference ensemble from ``state`` before checkpointing.
+
+        For ``inner_kernel="DE"`` in the adaptive (inner-kernel-tuning) modes,
+        ``state.parameter_override["ensemble"]`` is always an exact copy of
+        ``state.sampler_state.particles`` — see
+        ``_build_adaptive_inner_kernel_parameters``'s ``update_ensemble_parameters``,
+        which sets it to ``extend_params({"ensemble": smc_state.particles})`` every
+        step. Persisting it doubles the particle population's footprint in every
+        checkpoint file for no benefit, since ``_restore_checkpoint_ensemble``
+        recomputes it from ``sampler_state.particles`` on resume.
+        """
+        if config.inner_kernel == "DE" and isinstance(
+            state, StateWithParameterOverride
+        ):
+            return state._replace(
+                parameter_override={
+                    key: value
+                    for key, value in state.parameter_override.items()
+                    if key != "ensemble"
+                }
+            )
+        return state
+
+    def _restore_checkpoint_ensemble(
+        self, config: BlackJAXSMCConfig, state: Any
+    ) -> Any:
+        """Reconstruct the DE ensemble dropped by ``_checkpoint_safe_state``."""
+        if (
+            config.inner_kernel == "DE"
+            and isinstance(state, StateWithParameterOverride)
+            and "ensemble" not in state.parameter_override
+        ):
+            return state._replace(
+                parameter_override={
+                    **state.parameter_override,
+                    **extend_params(
+                        {"ensemble": state.sampler_state.particles}  # type: ignore[arg-type]
+                    ),
+                }
+            )
+        return state
+
     def _load_or_initialize_state(
         self,
         checkpoint_path: Optional[Path],
@@ -352,6 +395,7 @@ class BlackJAXSMCSampler(Sampler):
                 self._prev_elapsed = 0.0
             else:
                 self._prev_elapsed = float(checkpoint["elapsed_time"])
+                state = self._restore_checkpoint_ensemble(config, state)
                 logger.info(
                     "%s: resumed from checkpoint at n_iter=%d (%s)",
                     f"{self.sampler_name} ({self.mode.upper()})",
@@ -417,7 +461,7 @@ class BlackJAXSMCSampler(Sampler):
             return last_checkpoint_at
         return config.write_checkpoint(
             {
-                "state": state,
+                "state": self._checkpoint_safe_state(config, state),
                 "rng_key": rng_key,
                 "n_iter": n_completed_iterations,
                 "mode": self.mode,

--- a/src/jimgw/samplers/blackjax/smc_utils.py
+++ b/src/jimgw/samplers/blackjax/smc_utils.py
@@ -1,0 +1,56 @@
+"""SMC-specific helpers that aren't part of the sampling algorithm itself.
+
+Currently just the DE reference-ensemble checkpoint trim/restore pair (see
+[`jimgw.samplers.blackjax.utils`][] for the checkpoint mechanics these plug
+into) — split out from `smc.py` since they're specific to the SMC + DE
+combination, not shared with the nested-sampling backends.
+"""
+
+from typing import Any
+
+from blackjax.smc import extend_params
+from blackjax.smc.inner_kernel_tuning import StateWithParameterOverride
+
+from jimgw.samplers.config import BlackJAXSMCConfig
+
+
+def checkpoint_safe_state(config: BlackJAXSMCConfig, state: Any) -> Any:
+    """Drop the DE reference ensemble from ``state`` before checkpointing.
+
+    For ``inner_kernel="DE"`` in the adaptive (inner-kernel-tuning) modes,
+    ``state.parameter_override["ensemble"]`` is always an exact copy of
+    ``state.sampler_state.particles`` — see
+    ``BlackJAXSMCSampler._build_adaptive_inner_kernel_parameters``'s
+    ``update_ensemble_parameters``, which sets it to
+    ``extend_params({"ensemble": smc_state.particles})`` every step.
+    Persisting it doubles the particle population's footprint in every
+    checkpoint file for no benefit, since ``restore_checkpoint_ensemble``
+    recomputes it from ``sampler_state.particles`` on resume.
+    """
+    if config.inner_kernel == "DE" and isinstance(state, StateWithParameterOverride):
+        return state._replace(
+            parameter_override={
+                key: value
+                for key, value in state.parameter_override.items()
+                if key != "ensemble"
+            }
+        )
+    return state
+
+
+def restore_checkpoint_ensemble(config: BlackJAXSMCConfig, state: Any) -> Any:
+    """Reconstruct the DE ensemble dropped by ``checkpoint_safe_state``."""
+    if (
+        config.inner_kernel == "DE"
+        and isinstance(state, StateWithParameterOverride)
+        and "ensemble" not in state.parameter_override
+    ):
+        return state._replace(
+            parameter_override={
+                **state.parameter_override,
+                **extend_params(
+                    {"ensemble": state.sampler_state.particles}  # type: ignore[arg-type]
+                ),
+            }
+        )
+    return state

--- a/src/jimgw/samplers/blackjax/utils.py
+++ b/src/jimgw/samplers/blackjax/utils.py
@@ -1,0 +1,197 @@
+"""Checkpoint save/load/cleanup helpers shared by the BlackJAX SMC and nested-sampling backends.
+
+``BlackJAXSMCSampler``, ``BlackJAXNSSSampler``, and ``BlackJAXNSAWSampler`` each
+run their own JAX while-loop and periodically checkpoint it to
+``config.checkpoint_dir/checkpoint.pkl``. The load/save/cleanup mechanics
+(compute the path, try to resume, fall back to a fresh state on a corrupt or
+foreign checkpoint, gate saves on the configured interval, clean up on
+completion) are identical across the three; only the state shape, the extra
+per-run bookkeeping (SMC's acceptance/covariance histories vs. NS's ``dead``
+point list), and a couple of backend-specific hooks differ. This module holds
+that shared mechanics; each sampler supplies the differences via callbacks.
+"""
+
+import logging
+import pickle
+import shutil
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Optional
+
+import jax
+from jaxtyping import Key
+
+from jimgw.samplers.base import Sampler
+from jimgw.samplers.config import _CheckpointMixin
+
+logger = logging.getLogger(__name__)
+
+
+def prepare_checkpointing(config: _CheckpointMixin) -> tuple[Optional[Path], float]:
+    """Enable the JAX compile cache and return the checkpoint path and start time."""
+    checkpoint_path = (
+        config.checkpoint_dir / "checkpoint.pkl"
+        if config.checkpoint_dir is not None
+        else None
+    )
+    config.configure_jax_cache()
+    return checkpoint_path, time.perf_counter()
+
+
+def load_or_initialize_checkpoint(
+    sampler: Sampler,
+    checkpoint_path: Optional[Path],
+    config: _CheckpointMixin,
+    rng_key: Key,
+    initial_particles: Any,
+    initialize_state: Callable[..., Any],
+    initial_extra: dict[str, Any],
+    load_extra: Callable[[dict], dict[str, Any]],
+    *,
+    log_label: str,
+    after_load: Optional[Callable[[Any], Any]] = None,
+    is_stale: Optional[Callable[[int], bool]] = None,
+    stale_message: str = "checkpoint exceeds current schedule",
+) -> tuple[Any, Key, int, dict[str, Any]]:
+    """Load a compatible checkpoint or initialize a new sampler state.
+
+    ``initialize_state`` builds a fresh state from ``initial_particles``.
+    ``initial_extra``/``load_extra`` supply and restore backend-specific
+    extras (histories for SMC, the NS ``dead`` point list, ...). ``after_load``
+    post-processes a freshly loaded ``state`` — used for device/mesh placement
+    (NSS) or reconstructing a field dropped before checkpointing (SMC's DE
+    ensemble). ``is_stale`` optionally rejects a loaded checkpoint whose
+    ``n_iter`` no longer fits the current run (a fixed temperature ladder that
+    has since changed length) and falls back to a fresh state.
+
+    Only trusted checkpoint files may be loaded because pickle can execute
+    arbitrary code.
+    """
+    if not (
+        checkpoint_path is not None
+        and config.checkpoint_interval > 0
+        and checkpoint_path.exists()
+    ):
+        sampler._prev_elapsed = 0.0
+        return (
+            initialize_state(initial_particles),
+            rng_key,
+            0,
+            dict(initial_extra),
+        )
+
+    initial_rng_key = rng_key
+    try:
+        with open(checkpoint_path, "rb") as checkpoint_file:
+            checkpoint = pickle.load(checkpoint_file)
+        sampler._validate_checkpoint(checkpoint)
+        state = checkpoint["state"]
+        rng_key = checkpoint["rng_key"]
+        n_completed_iterations = checkpoint["n_iter"]
+        extra = load_extra(checkpoint)
+        if is_stale is not None and is_stale(n_completed_iterations):
+            logger.warning(
+                "%s: %s (n_iter=%d) — starting fresh.",
+                log_label,
+                stale_message,
+                n_completed_iterations,
+            )
+            rng_key = initial_rng_key
+            state = initialize_state(initial_particles)
+            n_completed_iterations = 0
+            extra = dict(initial_extra)
+            sampler._prev_elapsed = 0.0
+        else:
+            sampler._prev_elapsed = float(checkpoint["elapsed_time"])
+            if after_load is not None:
+                state = after_load(state)
+            logger.info(
+                "%s: resumed from checkpoint at n_iter=%d (%s)",
+                log_label,
+                n_completed_iterations,
+                checkpoint_path,
+            )
+        return state, rng_key, n_completed_iterations, extra
+    except (
+        OSError,
+        EOFError,
+        KeyError,
+        TypeError,
+        ValueError,
+        pickle.UnpicklingError,
+    ) as error:
+        logger.warning(
+            "%s: incompatible or corrupt checkpoint at %s (%s) — starting fresh.",
+            log_label,
+            checkpoint_path,
+            error,
+        )
+        sampler._prev_elapsed = 0.0
+        return (
+            initialize_state(initial_particles),
+            initial_rng_key,
+            0,
+            dict(initial_extra),
+        )
+
+
+def save_checkpoint_if_due(
+    sampler: Sampler,
+    config: _CheckpointMixin,
+    checkpoint_path: Optional[Path],
+    last_checkpoint_write_time: float,
+    run_start_time: float,
+    state: Any,
+    rng_key: Key,
+    n_completed_iterations: int,
+    extra: dict[str, Any],
+    *,
+    log_label: str,
+    before_save: Optional[
+        Callable[[Any, Key, dict[str, Any]], tuple[Any, Key, dict[str, Any]]]
+    ] = None,
+) -> float:
+    """Save a checkpoint when its interval has elapsed.
+
+    ``extra`` is merged into the common checkpoint payload (state, rng_key,
+    n_iter, sampler_name, elapsed_time) — use it for backend-specific fields
+    such as per-iteration histories or the NS ``dead`` point list.
+    ``before_save`` transforms ``(state, rng_key, extra)`` right before they
+    are written — e.g. NSS's ``jax.device_get`` on all three, or SMC's DE
+    ensemble strip on ``state`` alone. It is called only when a checkpoint is
+    actually due, so a host transfer here doesn't run every iteration.
+    Returns the last checkpoint time.
+    """
+    if not (
+        checkpoint_path is not None
+        and config.checkpoint_interval > 0
+        and time.perf_counter() - last_checkpoint_write_time
+        >= config.checkpoint_interval
+    ):
+        return last_checkpoint_write_time
+    if before_save is not None:
+        state, rng_key, extra = before_save(state, rng_key, extra)
+    return config.write_checkpoint(
+        {
+            "state": state,
+            "rng_key": rng_key,
+            "n_iter": n_completed_iterations,
+            "sampler_name": sampler.sampler_name,
+            "elapsed_time": sampler._prev_elapsed
+            + (time.perf_counter() - run_start_time),
+            **extra,
+        },
+        log_label,
+    )
+
+
+def remove_checkpoint_and_jax_cache(
+    config: _CheckpointMixin, checkpoint_path: Optional[Path]
+) -> None:
+    """Remove a completed run's checkpoint, JAX cache, and cache setting."""
+    if checkpoint_path is not None:
+        checkpoint_path.unlink(missing_ok=True)
+    if config.checkpoint_dir is not None:
+        shutil.rmtree(config.checkpoint_dir / "jax_cache", ignore_errors=True)
+        jax.config.update("jax_compilation_cache_dir", None)

--- a/src/jimgw/samplers/config.py
+++ b/src/jimgw/samplers/config.py
@@ -544,11 +544,11 @@ class BlackJAXSMCConfig(BaseSamplerConfig[Literal["blackjax-smc"]], _CheckpointM
 
     @model_validator(mode="after")
     def _validate_de_particle_count(self) -> Self:
-        if self.inner_kernel == "DE" and self.n_particles < 2:
+        if self.inner_kernel == "DE" and self.n_particles < 3:
             raise ValueError(
-                "BlackJAXSMCConfig: inner_kernel='DE' requires n_particles >= 2 "
-                f"(got {self.n_particles}) — the DE move needs two distinct "
-                "particles to form its difference vector."
+                "BlackJAXSMCConfig: inner_kernel='DE' requires n_particles >= 3 "
+                f"(got {self.n_particles}) — the two-particle DE edge case is "
+                "unsupported."
             )
         return self
 

--- a/src/jimgw/samplers/config.py
+++ b/src/jimgw/samplers/config.py
@@ -403,17 +403,40 @@ class BlackJAXSwiGConfig(
         return blocks
 
 
+class BlackJAXSMCGRWConfig(BaseModel):
+    """Gaussian random-walk inner-kernel settings for the BlackJAX SMC sampler.
+
+    The proposal covariance is estimated from the particles and rescaled each
+    tempering step toward ``target_acceptance_rate`` with gain
+    ``scale_adaptation_gain``; ``initial_cov_scale`` scales the starting
+    covariance.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    initial_cov_scale: float = Field(default=0.5, gt=0.0)
+    target_acceptance_rate: float = Field(default=0.234, gt=0.0, lt=1.0)
+    scale_adaptation_gain: float = Field(default=3.0, gt=0.0)
+
+
+class BlackJAXSMCDEConfig(BaseModel):
+    """Differential-evolution inner-kernel settings for the BlackJAX SMC sampler.
+
+    The bilby/dynesty-style move is ``x + gamma * (x_a - x_b)``. Its mix
+    probability and scale currently match the NS acceptance-walk kernel. This
+    empty model reserves a clear place for future DE settings and rejects
+    misspelled configuration keys.
+    """
+
+    model_config = {"extra": "forbid"}
+
+
 class BlackJAXSMCConfig(BaseSamplerConfig[Literal["blackjax-smc"]], _CheckpointMixin):
     """Configuration for the BlackJAX SMC sampler.
 
-    Parameters
-    ----------
-    batch_size : int, optional
-        Number of particles to process per sequential batch during the MCMC
-        update step. When ``batch_size > 0``, the sampler uses ``jax.lax.map``
-        instead of ``jax.vmap``, which reduces peak GPU memory at the cost
-        of sequential execution. ``0`` (default) uses the original full
-        ``jax.vmap`` behaviour.
+    ``inner_kernel`` selects ``"GRW"`` (adaptive-covariance random walk;
+    default) or ``"DE"`` (differential-evolution move) for the per-particle
+    MCMC step; settings live in the matching ``grw``/``de`` sub-config.
 
     !!! note
         Periodic parameters are **not** configured here.  Pass a ``periodic``
@@ -428,9 +451,10 @@ class BlackJAXSMCConfig(BaseSamplerConfig[Literal["blackjax-smc"]], _CheckpointM
     target_ess_fraction: Optional[float] = None
     # 0 = full vmap; >0 = lax.map batch size to reduce peak memory
     batch_size: int = Field(default=0, ge=0)
-    initial_cov_scale: float = Field(default=0.5, gt=0.0)
-    target_acceptance_rate: float = Field(default=0.234, gt=0.0, lt=1.0)
-    scale_adaptation_gain: float = Field(default=3.0, gt=0.0)
+
+    inner_kernel: Literal["GRW", "DE"] = "GRW"
+    grw: BlackJAXSMCGRWConfig = Field(default_factory=BlackJAXSMCGRWConfig)
+    de: BlackJAXSMCDEConfig = Field(default_factory=BlackJAXSMCDEConfig)
 
     persistent_sampling: bool = True
     temperature_ladder: Optional[list[float]] = None
@@ -499,6 +523,20 @@ class BlackJAXSMCConfig(BaseSamplerConfig[Literal["blackjax-smc"]], _CheckpointM
             warnings.warn(
                 "BlackJAXSMCConfig: ESS target has no effect when "
                 "`temperature_ladder` is provided (fixed-ladder mode).",
+                UserWarning,
+                stacklevel=2,
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _warn_about_inactive_kernel_settings(self) -> Self:
+        inactive_kernel = "de" if self.inner_kernel == "GRW" else "grw"
+        inactive_settings = getattr(self, inactive_kernel)
+        if inactive_settings.model_fields_set:
+            warnings.warn(
+                f"BlackJAXSMCConfig: `{inactive_kernel}` sub-config has non-default "
+                f"values but `inner_kernel='{self.inner_kernel}'` — the "
+                f"`{inactive_kernel}` settings will be ignored.",
                 UserWarning,
                 stacklevel=2,
             )

--- a/src/jimgw/samplers/config.py
+++ b/src/jimgw/samplers/config.py
@@ -181,7 +181,7 @@ class ParallelTemperingConfig(BaseModel):
     n_tempered_steps: int = Field(default=5, ge=1)
 
 
-class MALAConfig(BaseModel):
+class FlowMCMALAConfig(BaseModel):
     """MALA local-kernel settings for the flowMC backend.
 
     ``step_size`` may be a scalar ``float`` (applied uniformly to all
@@ -194,7 +194,7 @@ class MALAConfig(BaseModel):
     step_size: float | np.ndarray = 2e-3
 
 
-class HMCConfig(BaseModel):
+class FlowMCHMCConfig(BaseModel):
     """HMC local-kernel settings for the flowMC backend.
 
     ``step_size`` may be a scalar ``float`` (applied uniformly) or a 1-D
@@ -210,7 +210,7 @@ class HMCConfig(BaseModel):
     n_leapfrog_steps: int = Field(default=10, ge=1)
 
 
-class GRWConfig(BaseModel):
+class FlowMCGRWConfig(BaseModel):
     """Gaussian random-walk local-kernel settings for the flowMC backend.
 
     ``step_size`` may be a scalar ``float`` (applied uniformly to all
@@ -259,9 +259,9 @@ class FlowMCConfig(BaseSamplerConfig[Literal["flowmc"]], _CheckpointMixin):
     local_kernel: Literal["MALA", "HMC", "GRW"] = "MALA"
     parallel_tempering: Optional[ParallelTemperingConfig] = None
     # dict[str, Any] accepted here; Pydantic coerces it to the typed config via field_validator.
-    mala: MALAConfig | dict[str, Any] = Field(default_factory=MALAConfig)
-    hmc: HMCConfig | dict[str, Any] = Field(default_factory=HMCConfig)
-    grw: GRWConfig | dict[str, Any] = Field(default_factory=GRWConfig)
+    mala: FlowMCMALAConfig | dict[str, Any] = Field(default_factory=FlowMCMALAConfig)
+    hmc: FlowMCHMCConfig | dict[str, Any] = Field(default_factory=FlowMCHMCConfig)
+    grw: FlowMCGRWConfig | dict[str, Any] = Field(default_factory=FlowMCGRWConfig)
 
     rq_spline_hidden_units: list[int] = Field(default_factory=lambda: [128, 128])
     rq_spline_n_bins: int = Field(default=10, ge=1)

--- a/src/jimgw/samplers/config.py
+++ b/src/jimgw/samplers/config.py
@@ -542,6 +542,16 @@ class BlackJAXSMCConfig(BaseSamplerConfig[Literal["blackjax-smc"]], _CheckpointM
             )
         return self
 
+    @model_validator(mode="after")
+    def _validate_de_particle_count(self) -> Self:
+        if self.inner_kernel == "DE" and self.n_particles < 2:
+            raise ValueError(
+                "BlackJAXSMCConfig: inner_kernel='DE' requires n_particles >= 2 "
+                f"(got {self.n_particles}) — the DE move needs two distinct "
+                "particles to form its difference vector."
+            )
+        return self
+
     def _resolve_target_ess_fraction(self) -> float:
         """Return the ESS target as a fraction of n_particles."""
         if self.target_ess_fraction is not None:

--- a/src/jimgw/samplers/config.py
+++ b/src/jimgw/samplers/config.py
@@ -79,7 +79,7 @@ class _CheckpointMixin(BaseModel):
 
         Returns:
             Wall-clock time of the write (``time.perf_counter()``), suitable
-            for resetting the caller's ``last_checkpoint_at`` timer.
+            for resetting the caller's ``last_checkpoint_write_time`` timer.
         """
         assert self.checkpoint_dir is not None
         checkpoint_path = self.checkpoint_dir / "checkpoint.pkl"
@@ -88,13 +88,13 @@ class _CheckpointMixin(BaseModel):
         with open(temporary_path, "wb") as checkpoint_file:
             pickle.dump(data, checkpoint_file)
         temporary_path.replace(checkpoint_path)
-        checkpoint_written_at = time.perf_counter()
+        checkpoint_write_time = time.perf_counter()
         logger.debug(
             "%s: checkpoint saved at n_iter=%s",
             label,
             data.get("n_iter", "?"),
         )
-        return checkpoint_written_at
+        return checkpoint_write_time
 
     def configure_jax_cache(self) -> None:
         """Enable JAX's persistent XLA compilation cache under ``checkpoint_dir/jax_cache``.

--- a/src/jimgw/samplers/flowmc.py
+++ b/src/jimgw/samplers/flowmc.py
@@ -24,7 +24,12 @@ from flowMC.Sampler import Sampler as FlowMCSamplerBackend
 from jaxtyping import Array, Float, Key
 
 from jimgw.samplers.base import Sampler
-from jimgw.samplers.config import FlowMCConfig, GRWConfig, HMCConfig, MALAConfig
+from jimgw.samplers.config import (
+    FlowMCConfig,
+    FlowMCGRWConfig,
+    FlowMCHMCConfig,
+    FlowMCMALAConfig,
+)
 from jimgw.typing import FloatScalar
 
 logger = logging.getLogger(__name__)
@@ -197,15 +202,15 @@ class FlowMCSampler(Sampler):
 
         # Kernel-specific kwargs. isinstance checks narrow the type after Pydantic coercion.
         if config.local_kernel == "MALA":
-            assert isinstance(config.mala, MALAConfig)
+            assert isinstance(config.mala, FlowMCMALAConfig)
             common_kwargs["mala_step_size"] = config.mala.step_size
         elif config.local_kernel == "HMC":
-            assert isinstance(config.hmc, HMCConfig)
+            assert isinstance(config.hmc, FlowMCHMCConfig)
             common_kwargs["hmc_step_size"] = config.hmc.step_size
             common_kwargs["hmc_n_leapfrog"] = config.hmc.n_leapfrog_steps
             common_kwargs["condition_matrix"] = config.hmc.condition_matrix
         elif config.local_kernel == "GRW":
-            assert isinstance(config.grw, GRWConfig)
+            assert isinstance(config.grw, FlowMCGRWConfig)
             common_kwargs["grw_step_size"] = config.grw.step_size
 
         # PT-specific kwargs (only for PT bundles).

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -210,6 +210,23 @@ def test_checkpoint_defaults_do_not_activate_inactive_smc_settings():
     assert sampler_config.checkpoint_interval == 600.0
 
 
+def test_explicit_none_checkpoint_dir_disables_cli_checkpointing():
+    cfg = PipelineConfig.model_validate(
+        {
+            **_MINIMAL_RAW,
+            "sampler": {
+                "type": "blackjax-smc",
+                "checkpoint_dir": None,
+            },
+        }
+    )
+
+    sampler_config = _with_checkpoint(cfg.sampler, Path("checkpoints"))
+
+    assert sampler_config.checkpoint_dir is None
+    assert sampler_config.checkpoint_interval == 0.0
+
+
 def test_resolved_config_strips_inactive_smc_kernel_settings():
     cfg = PipelineConfig.model_validate(
         {

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -1,6 +1,8 @@
 """Unit tests for CLI config schema (TOML round-trips, validation, prior parsing)."""
 
 import tomllib
+import warnings
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
@@ -24,6 +26,8 @@ from jimgw.cli._config import (
     UniformSphereSpec,
     WaveformConfig,
 )
+from jimgw.cli._jim import _with_checkpoint
+from jimgw.cli._output import _resolved_config_data
 
 _MINIMAL_RAW = {
     "data": {
@@ -177,16 +181,59 @@ def test_extra_fields_rejected():
 
 def test_dump_resolved_round_trip():
     cfg = PipelineConfig.model_validate(_MINIMAL_RAW)
-    dumped = cfg.model_dump(mode="json")
-    # Strip inactive FlowMC kernel sub-configs (mirrors _output.py logic)
-    if dumped.get("sampler", {}).get("type") == "flowmc":
-        active = dumped["sampler"]["local_kernel"].lower()
-        for kernel in ("mala", "hmc", "grw"):
-            if kernel != active:
-                dumped["sampler"].pop(kernel, None)
+    dumped = _resolved_config_data(cfg)
     cfg2 = PipelineConfig.model_validate(dumped)
     assert cfg.waveform.approximant == cfg2.waveform.approximant
     assert cfg.seed == cfg2.seed
+
+
+def test_checkpoint_defaults_do_not_activate_inactive_smc_settings():
+    cfg = PipelineConfig.model_validate(
+        {
+            **_MINIMAL_RAW,
+            "sampler": {
+                "type": "blackjax-smc",
+                "inner_kernel": "DE",
+                "n_particles": 3,
+            },
+        }
+    )
+
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        warnings.simplefilter("always")
+        sampler_config = _with_checkpoint(cfg.sampler, Path("checkpoints"))
+
+    assert not any(
+        "sub-config" in str(warning.message) for warning in captured_warnings
+    )
+    assert sampler_config.checkpoint_dir == Path("checkpoints")
+    assert sampler_config.checkpoint_interval == 600.0
+
+
+def test_resolved_config_strips_inactive_smc_kernel_settings():
+    cfg = PipelineConfig.model_validate(
+        {
+            **_MINIMAL_RAW,
+            "sampler": {
+                "type": "blackjax-smc",
+                "inner_kernel": "DE",
+                "n_particles": 3,
+            },
+        }
+    )
+
+    dumped = _resolved_config_data(cfg)
+    assert dumped["sampler"]["de"] == {}
+    assert "grw" not in dumped["sampler"]
+
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        warnings.simplefilter("always")
+        restored = PipelineConfig.model_validate(dumped)
+
+    assert restored.sampler.inner_kernel == "DE"
+    assert not any(
+        "sub-config" in str(warning.message) for warning in captured_warnings
+    )
 
 
 def test_file_config_from_toml():

--- a/tests/unit/samplers/blackjax/test_smc.py
+++ b/tests/unit/samplers/blackjax/test_smc.py
@@ -80,6 +80,13 @@ def _init_pos(n: int, seed: int = 99) -> jax.Array:
     return jax.random.uniform(jax.random.key(seed), (n, 2))
 
 
+def test_smc_de_requires_three_particles():
+    with pytest.raises(ValueError, match="n_particles >= 3"):
+        BlackJAXSMCConfig(inner_kernel="DE", n_particles=2)
+
+    assert BlackJAXSMCConfig(inner_kernel="DE", n_particles=3).n_particles == 3
+
+
 def test_smc_sample_and_get_samples():
     sampler = _make_sampler()
     sampler.sample(jax.random.key(0), _init_pos(200))

--- a/tests/unit/samplers/blackjax/test_smc.py
+++ b/tests/unit/samplers/blackjax/test_smc.py
@@ -869,6 +869,9 @@ def test_smc_de_checkpoint_records_inner_kernel(tmp_path, monkeypatch):
     with open(checkpoint_path, "rb") as checkpoint_file:
         checkpoint = pickle.load(checkpoint_file)
     assert checkpoint["inner_kernel"] == "DE"
+    # The DE reference ensemble duplicates state.sampler_state.particles; it
+    # must be dropped before pickling and rebuilt on resume, not persisted.
+    assert "ensemble" not in checkpoint["state"].parameter_override
 
     with pytest.raises(ValueError, match="different SMC inner kernel"):
         make_sampler("GRW")._validate_checkpoint(checkpoint)

--- a/tests/unit/samplers/blackjax/test_smc.py
+++ b/tests/unit/samplers/blackjax/test_smc.py
@@ -42,9 +42,6 @@ def _make_sampler(
             n_particles=n_particles,
             n_mcmc_steps_per_dim=5,
             target_ess=50,
-            initial_cov_scale=0.5,
-            target_acceptance_rate=0.234,
-            scale_adaptation_gain=3.0,
         )
     parameter_names = prior.parameter_names  # ("x", "y")
 
@@ -163,12 +160,20 @@ def test_smc_ap_diagnostics():
     assert diag["log_Z_error"] >= 0.0
 
 
-def test_smc_n_evals_formula():
-    """n_likelihood_evaluations == n_mcmc * n_iter * n_particles."""
+@pytest.mark.parametrize("inner_kernel", ["GRW", "DE"])
+def test_smc_n_evals_formula(inner_kernel):
+    """n_likelihood_evaluations == n_mcmc * n_iter * n_particles for both kernels
+    (one log-density eval per proposal, regardless of proposal shape)."""
     n_particles = 200
     n_mcmc_per_dim = 5
     n_dims = 2
-    sampler = _make_sampler(n_particles=n_particles)
+    config = BlackJAXSMCConfig(
+        n_particles=n_particles,
+        n_mcmc_steps_per_dim=n_mcmc_per_dim,
+        target_ess=50,
+        inner_kernel=inner_kernel,
+    )
+    sampler = _make_sampler(n_particles=n_particles, config=config)
     sampler.sample(jax.random.key(5), _init_pos(n_particles))
     diag = sampler.get_diagnostics()
 
@@ -367,28 +372,30 @@ def test_smc_checkpoint_file_created(tmp_path, monkeypatch):
         config=config,
     )
     # Suppress deletion of only the checkpoint file so we can inspect it after sampling.
-    ckpt_path = tmp_path / "checkpoint.pkl"
-    _orig_unlink = Path.unlink
+    checkpoint_path = tmp_path / "checkpoint.pkl"
+    original_unlink = Path.unlink
     monkeypatch.setattr(
         Path,
         "unlink",
         lambda self, missing_ok=False: (
-            None if self == ckpt_path else _orig_unlink(self, missing_ok=missing_ok)
+            None
+            if self == checkpoint_path
+            else original_unlink(self, missing_ok=missing_ok)
         ),
     )
     sampler.sample(jax.random.key(42), _init_pos(200))
-    monkeypatch.setattr(Path, "unlink", _orig_unlink)
-    assert ckpt_path.exists(), "Checkpoint was never written"
-    with open(ckpt_path, "rb") as f:
-        ckpt = pickle.load(f)
-    assert "elapsed_time" in ckpt
-    assert ckpt["elapsed_time"] >= 0.0
-    assert ckpt["sampler_name"] == sampler.sampler_name
-    assert ckpt["mode"] == sampler.mode
+    monkeypatch.setattr(Path, "unlink", original_unlink)
+    assert checkpoint_path.exists(), "Checkpoint was never written"
+    with open(checkpoint_path, "rb") as checkpoint_file:
+        checkpoint = pickle.load(checkpoint_file)
+    assert "elapsed_time" in checkpoint
+    assert checkpoint["elapsed_time"] >= 0.0
+    assert checkpoint["sampler_name"] == sampler.sampler_name
+    assert checkpoint["mode"] == sampler.mode
 
     # Now let a clean run delete it.
-    ckpt_path.unlink()
-    assert not ckpt_path.exists()
+    checkpoint_path.unlink()
+    assert not checkpoint_path.exists()
 
 
 @pytest.mark.parametrize(
@@ -416,11 +423,19 @@ def test_smc_mode_is_derived_from_config(
 def test_smc_checkpoint_validation_checks_mode():
     sampler = _make_sampler()
     sampler._validate_checkpoint(
-        {"sampler_name": sampler.sampler_name, "mode": sampler.mode}
+        {
+            "sampler_name": sampler.sampler_name,
+            "mode": sampler.mode,
+            "inner_kernel": "GRW",
+        }
     )
     with pytest.raises(ValueError, match="different SMC mode"):
         sampler._validate_checkpoint(
-            {"sampler_name": sampler.sampler_name, "mode": "fp"}
+            {
+                "sampler_name": sampler.sampler_name,
+                "mode": "fp",
+                "inner_kernel": "GRW",
+            }
         )
 
 
@@ -435,14 +450,11 @@ def test_smc_resume_gives_same_result(tmp_path, monkeypatch):
     likelihood = _GaussianLikelihood()
     parameter_names = prior.parameter_names
 
-    def _make(checkpoint_dir=None):
+    def make_sampler(checkpoint_dir=None):
         config = BlackJAXSMCConfig(
             n_particles=200,
             n_mcmc_steps_per_dim=5,
             target_ess=50,
-            initial_cov_scale=0.5,
-            target_acceptance_rate=0.234,
-            scale_adaptation_gain=3.0,
             checkpoint_dir=checkpoint_dir,
             checkpoint_interval=1e-9 if checkpoint_dir is not None else 0.0,
         )
@@ -464,31 +476,32 @@ def test_smc_resume_gives_same_result(tmp_path, monkeypatch):
             config=config,
         )
 
-    s_a = _make(checkpoint_dir=None)
-    s_a.sample(jax.random.key(0), _init_pos(200))
-    log_z_a = s_a.get_diagnostics()["log_Z"]
+    reference_sampler = make_sampler(checkpoint_dir=None)
+    reference_sampler.sample(jax.random.key(0), _init_pos(200))
+    reference_log_evidence = reference_sampler.get_diagnostics()["log_Z"]
 
-    # Run B: suppress deletion of the checkpoint file only (simulates a crash leaving it behind).
-    ckpt_path = tmp_path / "checkpoint.pkl"
-    _orig_unlink = Path.unlink
+    checkpoint_path = tmp_path / "checkpoint.pkl"
+    original_unlink = Path.unlink
     monkeypatch.setattr(
         Path,
         "unlink",
         lambda self, missing_ok=False: (
-            None if self == ckpt_path else _orig_unlink(self, missing_ok=missing_ok)
+            None
+            if self == checkpoint_path
+            else original_unlink(self, missing_ok=missing_ok)
         ),
     )
-    s_b = _make(checkpoint_dir=tmp_path)
-    s_b.sample(jax.random.key(0), _init_pos(200))
-    monkeypatch.setattr(Path, "unlink", _orig_unlink)
-    assert ckpt_path.exists(), "Checkpoint was never written"
+    interrupted_sampler = make_sampler(checkpoint_dir=tmp_path)
+    interrupted_sampler.sample(jax.random.key(0), _init_pos(200))
+    monkeypatch.setattr(Path, "unlink", original_unlink)
+    assert checkpoint_path.exists(), "Checkpoint was never written"
 
-    # Run C: resumes from B's checkpoint → same RNG sequence → same log_Z.
-    # On clean completion C deletes the checkpoint.
-    s_c = _make(checkpoint_dir=tmp_path)
-    s_c.sample(jax.random.key(0), _init_pos(200))
+    resumed_sampler = make_sampler(checkpoint_dir=tmp_path)
+    resumed_sampler.sample(jax.random.key(0), _init_pos(200))
 
-    assert s_c.get_diagnostics()["log_Z"] == pytest.approx(log_z_a, rel=1e-6)
+    assert resumed_sampler.get_diagnostics()["log_Z"] == pytest.approx(
+        reference_log_evidence, rel=1e-6
+    )
     assert not (tmp_path / "checkpoint.pkl").exists(), "Checkpoint was not cleaned up"
 
 
@@ -507,14 +520,11 @@ def test_smc_checkpoint_failure_restores_caller_rng_key(tmp_path):
     likelihood = _GaussianLikelihood()
     parameter_names = prior.parameter_names
 
-    def _make(checkpoint_dir=None):
+    def make_sampler(checkpoint_dir=None):
         config = BlackJAXSMCConfig(
             n_particles=200,
             n_mcmc_steps_per_dim=5,
             target_ess=50,
-            initial_cov_scale=0.5,
-            target_acceptance_rate=0.234,
-            scale_adaptation_gain=3.0,
             checkpoint_dir=checkpoint_dir,
             checkpoint_interval=1e-9 if checkpoint_dir is not None else 0.0,
         )
@@ -538,15 +548,13 @@ def test_smc_checkpoint_failure_restores_caller_rng_key(tmp_path):
 
     caller_key = jax.random.key(7)
 
-    reference = _make(checkpoint_dir=None)
-    reference.sample(caller_key, _init_pos(200))
-    log_z_reference = reference.get_diagnostics()["log_Z"]
+    reference_sampler = make_sampler(checkpoint_dir=None)
+    reference_sampler.sample(caller_key, _init_pos(200))
+    reference_log_evidence = reference_sampler.get_diagnostics()["log_Z"]
 
-    sampler = _make(checkpoint_dir=tmp_path)
-    ckpt_path = tmp_path / "checkpoint.pkl"
-    # Valid enough to pass `_validate_checkpoint` and overwrite `rng_key` with
-    # a decoy key, but missing "n_iter" so loading fails right after.
-    with open(ckpt_path, "wb") as f:
+    sampler = make_sampler(checkpoint_dir=tmp_path)
+    checkpoint_path = tmp_path / "checkpoint.pkl"
+    with open(checkpoint_path, "wb") as checkpoint_file:
         pickle.dump(
             {
                 "sampler_name": sampler.sampler_name,
@@ -554,13 +562,13 @@ def test_smc_checkpoint_failure_restores_caller_rng_key(tmp_path):
                 "state": None,
                 "rng_key": jax.random.key(999),
             },
-            f,
+            checkpoint_file,
         )
 
     sampler.sample(caller_key, _init_pos(200))
 
     assert sampler.get_diagnostics()["log_Z"] == pytest.approx(
-        log_z_reference, rel=1e-6
+        reference_log_evidence, rel=1e-6
     )
 
 
@@ -579,9 +587,6 @@ def _make_sampler_batched(
         n_particles=n_particles,
         n_mcmc_steps_per_dim=5,
         target_ess=50,
-        initial_cov_scale=0.5,
-        target_acceptance_rate=0.234,
-        scale_adaptation_gain=3.0,
         batch_size=batch_size,
     )
     parameter_names = prior.parameter_names
@@ -663,3 +668,304 @@ def test_smc_particle_batch_size_at_mode():
     assert isinstance(result, dict)
     assert "samples" in result
     assert result["samples"].shape[0] > 0
+
+
+def _make_sampler_de(
+    n_particles: int = 400,
+    persistent_sampling: bool = True,
+    temperature_ladder: list[float] | None = None,
+) -> BlackJAXSMCSampler:
+    """SMC sampler using the differential-evolution inner kernel.
+
+    Adaptive by default; pass ``temperature_ladder`` for a fixed-ladder run.
+    """
+    prior = CombinePrior(
+        [
+            UniformPrior(0.0, 1.0, parameter_names=["x"]),
+            UniformPrior(0.0, 1.0, parameter_names=["y"]),
+        ]
+    )
+    likelihood = _GaussianLikelihood()
+    if temperature_ladder is not None:
+        config = BlackJAXSMCConfig(
+            n_particles=n_particles,
+            n_mcmc_steps_per_dim=10,
+            inner_kernel="DE",
+            persistent_sampling=persistent_sampling,
+            temperature_ladder=temperature_ladder,
+        )
+    else:
+        config = BlackJAXSMCConfig(
+            n_particles=n_particles,
+            n_mcmc_steps_per_dim=10,
+            inner_kernel="DE",
+            persistent_sampling=persistent_sampling,
+            target_ess=n_particles // 2,
+        )
+    parameter_names = prior.parameter_names
+
+    def log_prior_fn(arr):
+        return prior.log_prob(dict(zip(parameter_names, arr, strict=True)))
+
+    def log_likelihood_fn(arr):
+        return likelihood.evaluate(dict(zip(parameter_names, arr, strict=True)))
+
+    def log_posterior_fn(arr):
+        return log_prior_fn(arr) + log_likelihood_fn(arr)
+
+    return BlackJAXSMCSampler(
+        n_dims=len(parameter_names),
+        log_prior_fn=log_prior_fn,
+        log_likelihood_fn=log_likelihood_fn,
+        log_posterior_fn=log_posterior_fn,
+        config=config,
+    )
+
+
+def test_smc_de_samples_in_prior_support():
+    sampler = _make_sampler_de(n_particles=400)
+    sampler.sample(jax.random.key(20), _init_pos(400))
+    result = sampler.get_samples()
+
+    assert result["samples"].ndim == 2
+    assert result["samples"].shape[1] == 2
+    assert result["samples"].shape[0] > 0
+    assert np.all(result["samples"] >= 0.0) and np.all(result["samples"] <= 1.0)
+
+
+def test_smc_de_ap_diagnostics_no_cov_scale():
+    """DE inner kernel: acceptance history is kept; cov-scale history is empty."""
+    sampler = _make_sampler_de(n_particles=400)
+    sampler.sample(jax.random.key(22), _init_pos(400))
+    diag = sampler.get_diagnostics()
+
+    assert diag["n_iterations"] > 0
+    assert len(diag["acceptance_history"]) == diag["n_iterations"]
+    assert np.all(np.isfinite(diag["acceptance_history"]))
+    assert len(diag["cov_scale_history"]) == 0
+    assert float(diag["tempering_schedule"][-1]) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_smc_de_at_mode_runs():
+    sampler = _make_sampler_de(n_particles=400, persistent_sampling=False)
+    assert sampler.mode == "at"
+    sampler.sample(jax.random.key(23), _init_pos(400))
+    result = sampler.get_samples()
+    assert result["samples"].shape[0] > 0
+    assert np.all(result["samples"] >= 0.0) and np.all(result["samples"] <= 1.0)
+
+
+def test_smc_de_evidence_matches_grw():
+    """DE and GRW agree with the analytic evidence for a 2-D Gaussian.
+
+    The analytic log evidence over the unit square is approximately
+    ``log(2 * pi * sigma**2)`` because truncation is negligible.
+    """
+    log_evidences = {}
+    for inner_kernel in ("GRW", "DE"):
+        prior = CombinePrior(
+            [
+                UniformPrior(0.0, 1.0, parameter_names=["x"]),
+                UniformPrior(0.0, 1.0, parameter_names=["y"]),
+            ]
+        )
+        likelihood = _GaussianLikelihood()
+        config = BlackJAXSMCConfig(
+            n_particles=1500,
+            n_mcmc_steps_per_dim=15,
+            target_ess=750,
+            inner_kernel=inner_kernel,
+        )
+        parameter_names = prior.parameter_names
+
+        def log_prior_fn(arr, parameter_names=parameter_names, prior=prior):
+            return prior.log_prob(dict(zip(parameter_names, arr, strict=True)))
+
+        def log_likelihood_fn(
+            arr, parameter_names=parameter_names, likelihood=likelihood
+        ):
+            return likelihood.evaluate(dict(zip(parameter_names, arr, strict=True)))
+
+        def log_posterior_fn(
+            arr,
+            log_prior_fn=log_prior_fn,
+            log_likelihood_fn=log_likelihood_fn,
+        ):
+            return log_prior_fn(arr) + log_likelihood_fn(arr)
+
+        sampler = BlackJAXSMCSampler(
+            n_dims=2,
+            log_prior_fn=log_prior_fn,
+            log_likelihood_fn=log_likelihood_fn,
+            log_posterior_fn=log_posterior_fn,
+            config=config,
+        )
+        sampler.sample(jax.random.key(24), _init_pos(1500))
+        log_evidences[inner_kernel] = sampler.get_diagnostics()["log_Z"]
+
+    analytic = float(np.log(2 * np.pi * _SIGMA**2))
+    assert log_evidences["DE"] == pytest.approx(analytic, abs=0.15)
+    assert log_evidences["DE"] == pytest.approx(log_evidences["GRW"], abs=0.15)
+
+
+def test_smc_de_checkpoint_records_inner_kernel(tmp_path, monkeypatch):
+    """DE checkpoints carry inner_kernel; a GRW sampler refuses to resume from one."""
+    prior = CombinePrior(
+        [
+            UniformPrior(0.0, 1.0, parameter_names=["x"]),
+            UniformPrior(0.0, 1.0, parameter_names=["y"]),
+        ]
+    )
+    likelihood = _GaussianLikelihood()
+    parameter_names = prior.parameter_names
+
+    def log_prior_fn(arr):
+        return prior.log_prob(dict(zip(parameter_names, arr, strict=True)))
+
+    def log_likelihood_fn(arr):
+        return likelihood.evaluate(dict(zip(parameter_names, arr, strict=True)))
+
+    def log_posterior_fn(arr):
+        return log_prior_fn(arr) + log_likelihood_fn(arr)
+
+    def make_sampler(inner_kernel):
+        return BlackJAXSMCSampler(
+            n_dims=2,
+            log_prior_fn=log_prior_fn,
+            log_likelihood_fn=log_likelihood_fn,
+            log_posterior_fn=log_posterior_fn,
+            config=BlackJAXSMCConfig(
+                n_particles=200,
+                n_mcmc_steps_per_dim=5,
+                target_ess=50,
+                inner_kernel=inner_kernel,
+                checkpoint_dir=tmp_path,
+                checkpoint_interval=1e-9,
+            ),
+        )
+
+    checkpoint_path = tmp_path / "checkpoint.pkl"
+    original_unlink = Path.unlink
+    monkeypatch.setattr(
+        Path,
+        "unlink",
+        lambda self, missing_ok=False: (
+            None
+            if self == checkpoint_path
+            else original_unlink(self, missing_ok=missing_ok)
+        ),
+    )
+    make_sampler("DE").sample(jax.random.key(25), _init_pos(200))
+    monkeypatch.setattr(Path, "unlink", original_unlink)
+
+    with open(checkpoint_path, "rb") as checkpoint_file:
+        checkpoint = pickle.load(checkpoint_file)
+    assert checkpoint["inner_kernel"] == "DE"
+
+    with pytest.raises(ValueError, match="different SMC inner kernel"):
+        make_sampler("GRW")._validate_checkpoint(checkpoint)
+    make_sampler("DE")._validate_checkpoint(checkpoint)
+
+
+def test_smc_de_resume_gives_same_result(tmp_path, monkeypatch):
+    """A DE run resumed from a crashed checkpoint reproduces the uninterrupted log_Z."""
+    prior = CombinePrior(
+        [
+            UniformPrior(0.0, 1.0, parameter_names=["x"]),
+            UniformPrior(0.0, 1.0, parameter_names=["y"]),
+        ]
+    )
+    likelihood = _GaussianLikelihood()
+    parameter_names = prior.parameter_names
+
+    def log_prior_fn(arr):
+        return prior.log_prob(dict(zip(parameter_names, arr, strict=True)))
+
+    def log_likelihood_fn(arr):
+        return likelihood.evaluate(dict(zip(parameter_names, arr, strict=True)))
+
+    def log_posterior_fn(arr):
+        return log_prior_fn(arr) + log_likelihood_fn(arr)
+
+    def make_sampler(checkpoint_dir=None):
+        return BlackJAXSMCSampler(
+            n_dims=2,
+            log_prior_fn=log_prior_fn,
+            log_likelihood_fn=log_likelihood_fn,
+            log_posterior_fn=log_posterior_fn,
+            config=BlackJAXSMCConfig(
+                n_particles=300,
+                n_mcmc_steps_per_dim=5,
+                target_ess=80,
+                inner_kernel="DE",
+                checkpoint_dir=checkpoint_dir,
+                checkpoint_interval=1e-9 if checkpoint_dir is not None else 0.0,
+            ),
+        )
+
+    initial_particles = _init_pos(300)
+    reference_sampler = make_sampler()
+    reference_sampler.sample(jax.random.key(0), initial_particles)
+    reference_log_evidence = reference_sampler.get_diagnostics()["log_Z"]
+
+    checkpoint_path = tmp_path / "checkpoint.pkl"
+    original_unlink = Path.unlink
+    monkeypatch.setattr(
+        Path,
+        "unlink",
+        lambda self, missing_ok=False: (
+            None
+            if self == checkpoint_path
+            else original_unlink(self, missing_ok=missing_ok)
+        ),
+    )
+    make_sampler(checkpoint_dir=tmp_path).sample(jax.random.key(0), initial_particles)
+    monkeypatch.setattr(Path, "unlink", original_unlink)
+    assert checkpoint_path.exists(), "Checkpoint was never written"
+
+    resumed_sampler = make_sampler(checkpoint_dir=tmp_path)
+    resumed_sampler.sample(jax.random.key(0), initial_particles)
+    assert resumed_sampler.get_diagnostics()["log_Z"] == pytest.approx(
+        reference_log_evidence, rel=1e-6
+    )
+    assert not checkpoint_path.exists(), "Checkpoint was not cleaned up"
+
+
+_DE_TEMPERATURE_LADDER = [0.0, 0.05, 0.15, 0.35, 0.65, 1.0]
+
+
+def test_smc_de_fp_evidence_and_mixing():
+    """FP + DE: evidence matches analytic, and the refreshed reference ensemble
+    keeps the chain mixing at the final temperature (a frozen prior-width
+    ensemble would collapse acceptance to ~0 by then)."""
+    sampler = _make_sampler_de(
+        n_particles=800, temperature_ladder=_DE_TEMPERATURE_LADDER
+    )
+    assert sampler.mode == "fp"
+    sampler.sample(jax.random.key(30), _init_pos(800))
+
+    result = sampler.get_samples()
+    assert np.all(result["samples"] >= 0.0) and np.all(result["samples"] <= 1.0)
+
+    diag = sampler.get_diagnostics()
+    analytic = float(np.log(2 * np.pi * _SIGMA**2))
+    assert diag["log_Z"] == pytest.approx(analytic, abs=0.2)
+    assert diag["acceptance_history"][-1] > 0.1
+
+
+def test_smc_de_ft_runs():
+    sampler = _make_sampler_de(
+        n_particles=600,
+        persistent_sampling=False,
+        temperature_ladder=_DE_TEMPERATURE_LADDER,
+    )
+    assert sampler.mode == "ft"
+    sampler.sample(jax.random.key(31), _init_pos(600))
+
+    result = sampler.get_samples()
+    assert np.all(result["samples"] >= 0.0) and np.all(result["samples"] <= 1.0)
+    assert abs(float(result["samples"].mean()) - _MU) < 0.04
+
+    diag = sampler.get_diagnostics()
+    assert len(diag["ess_history"]) == len(_DE_TEMPERATURE_LADDER) - 1
+    assert diag["acceptance_history"][-1] > 0.1

--- a/tests/unit/samplers/blackjax/test_smc.py
+++ b/tests/unit/samplers/blackjax/test_smc.py
@@ -559,6 +559,7 @@ def test_smc_checkpoint_failure_restores_caller_rng_key(tmp_path):
             {
                 "sampler_name": sampler.sampler_name,
                 "mode": sampler.mode,
+                "inner_kernel": sampler._config.inner_kernel,
                 "state": None,
                 "rng_key": jax.random.key(999),
             },

--- a/tests/unit/samplers/blackjax/test_smc.py
+++ b/tests/unit/samplers/blackjax/test_smc.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import pickle
 from pathlib import Path
 from typing import Optional
@@ -403,6 +404,56 @@ def test_smc_checkpoint_file_created(tmp_path, monkeypatch):
     # Now let a clean run delete it.
     checkpoint_path.unlink()
     assert not checkpoint_path.exists()
+
+
+def test_smc_fixed_ladder_stale_checkpoint_restarts_fresh(
+    tmp_path, monkeypatch, caplog
+):
+    """A fixed-ladder run whose checkpoint n_iter exceeds the current ladder length
+    restarts fresh rather than resuming with an out-of-range iteration count."""
+    long_ladder = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
+    checkpoint_path = tmp_path / "checkpoint.pkl"
+    original_unlink = Path.unlink
+    monkeypatch.setattr(
+        Path,
+        "unlink",
+        lambda self, missing_ok=False: (
+            None
+            if self == checkpoint_path
+            else original_unlink(self, missing_ok=missing_ok)
+        ),
+    )
+    long_sampler = _make_sampler(
+        config=BlackJAXSMCConfig(
+            n_particles=200,
+            n_mcmc_steps_per_dim=5,
+            temperature_ladder=long_ladder,
+            checkpoint_dir=tmp_path,
+            checkpoint_interval=1e-9,
+        )
+    )
+    long_sampler.sample(jax.random.key(7), _init_pos(200))
+    monkeypatch.setattr(Path, "unlink", original_unlink)
+    assert checkpoint_path.exists(), "Checkpoint was never written"
+    with open(checkpoint_path, "rb") as checkpoint_file:
+        checkpoint = pickle.load(checkpoint_file)
+    assert checkpoint["n_iter"] == len(long_ladder) - 1
+
+    short_ladder = [0.0, 0.5, 1.0]
+    short_sampler = _make_sampler(
+        config=BlackJAXSMCConfig(
+            n_particles=200,
+            n_mcmc_steps_per_dim=5,
+            temperature_ladder=short_ladder,
+            checkpoint_dir=tmp_path,
+            checkpoint_interval=1e-9,
+        )
+    )
+    with caplog.at_level(logging.WARNING):
+        short_sampler.sample(jax.random.key(7), _init_pos(200))
+    assert "exceeds current schedule" in caplog.text
+    assert short_sampler._n_iterations == len(short_ladder) - 1
+    assert not checkpoint_path.exists(), "Checkpoint was not cleaned up"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/samplers/test_config.py
+++ b/tests/unit/samplers/test_config.py
@@ -12,9 +12,9 @@ from jimgw.samplers.config import (
     BlackJAXSMCConfig,
     BlackJAXSwiGConfig,
     FlowMCConfig,
-    GRWConfig,
-    HMCConfig,
-    MALAConfig,
+    FlowMCGRWConfig,
+    FlowMCHMCConfig,
+    FlowMCMALAConfig,
     ParallelTemperingConfig,
     SamplerConfig,
 )
@@ -172,7 +172,7 @@ def test_flowmc_pt_off_with_none():
 def test_flowmc_irrelevant_kernel_warns():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        FlowMCConfig(local_kernel="MALA", hmc=HMCConfig(step_size=0.5))
+        FlowMCConfig(local_kernel="MALA", hmc=FlowMCHMCConfig(step_size=0.5))
     assert any("hmc" in str(warning.message).lower() for warning in w)
 
 
@@ -188,7 +188,7 @@ def test_flowmc_irrelevant_parallel_tempering_warns():
 def test_flowmc_no_spurious_warning_when_kernel_matches():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        FlowMCConfig(local_kernel="HMC", hmc=HMCConfig(step_size=0.5))
+        FlowMCConfig(local_kernel="HMC", hmc=FlowMCHMCConfig(step_size=0.5))
     kernel_warnings = [x for x in w if "hmc" in str(x.message).lower()]
     assert len(kernel_warnings) == 0
 
@@ -299,35 +299,35 @@ def test_smc_fraction_warns_with_fixed_ladder():
 
 
 def test_mala_step_size_scalar():
-    cfg = MALAConfig(step_size=1e-2)
+    cfg = FlowMCMALAConfig(step_size=1e-2)
     assert cfg.step_size == 1e-2
 
 
 def test_mala_step_size_array():
     arr = np.array([1e-2, 2e-2, 3e-2])
-    cfg = MALAConfig(step_size=arr)
+    cfg = FlowMCMALAConfig(step_size=arr)
     np.testing.assert_array_equal(cfg.step_size, arr)
 
 
 def test_grw_step_size_array():
     arr = np.array([5e-3, 1e-2])
-    cfg = GRWConfig(step_size=arr)
+    cfg = FlowMCGRWConfig(step_size=arr)
     np.testing.assert_array_equal(cfg.step_size, arr)
 
 
 def test_hmc_condition_matrix_scalar():
-    cfg = HMCConfig(condition_matrix=2.0)
+    cfg = FlowMCHMCConfig(condition_matrix=2.0)
     assert cfg.condition_matrix == 2.0
 
 
 def test_hmc_condition_matrix_array():
     arr = np.array([1.0, 2.0, 0.5])
-    cfg = HMCConfig(condition_matrix=arr)
+    cfg = FlowMCHMCConfig(condition_matrix=arr)
     np.testing.assert_array_equal(cfg.condition_matrix, arr)
 
 
 def test_hmc_defaults():
-    cfg = HMCConfig()
+    cfg = FlowMCHMCConfig()
     assert cfg.step_size == 2e-3
     assert cfg.condition_matrix == 1.0
     assert cfg.n_leapfrog_steps == 10

--- a/tests/unit/samplers/test_config.py
+++ b/tests/unit/samplers/test_config.py
@@ -10,6 +10,8 @@ from jimgw.samplers.config import (
     BlackJAXNSAWConfig,
     BlackJAXNSSConfig,
     BlackJAXSMCConfig,
+    BlackJAXSMCDEConfig,
+    BlackJAXSMCGRWConfig,
     BlackJAXSwiGConfig,
     FlowMCConfig,
     FlowMCGRWConfig,
@@ -169,11 +171,11 @@ def test_flowmc_pt_off_with_none():
     assert cfg.parallel_tempering is None
 
 
-def test_flowmc_irrelevant_kernel_warns():
-    with warnings.catch_warnings(record=True) as w:
+def test_flowmc_warns_when_inactive_kernel_settings_are_provided():
+    with warnings.catch_warnings(record=True) as captured_warnings:
         warnings.simplefilter("always")
         FlowMCConfig(local_kernel="MALA", hmc=FlowMCHMCConfig(step_size=0.5))
-    assert any("hmc" in str(warning.message).lower() for warning in w)
+    assert any("hmc" in str(warning.message).lower() for warning in captured_warnings)
 
 
 def test_flowmc_irrelevant_parallel_tempering_warns():
@@ -293,9 +295,37 @@ def test_smc_fraction_warns_with_fixed_ladder():
     )
 
 
-# ---------------------------------------------------------------------------
-# C: New kernel sub-config features (array step sizes, condition_matrix)
-# ---------------------------------------------------------------------------
+def test_smc_inner_kernel_default():
+    assert BlackJAXSMCConfig().inner_kernel == "GRW"
+
+
+def test_smc_inner_kernel_de_selected():
+    assert BlackJAXSMCConfig(inner_kernel="DE").inner_kernel == "DE"
+
+
+def test_smc_inner_kernel_rejects_lowercase():
+    with pytest.raises(ValidationError):
+        BlackJAXSMCConfig(inner_kernel="de")
+
+
+def test_smc_warns_when_inactive_kernel_settings_are_provided():
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        warnings.simplefilter("always")
+        BlackJAXSMCConfig(
+            inner_kernel="DE", grw=BlackJAXSMCGRWConfig(initial_cov_scale=0.9)
+        )
+    assert any("grw" in str(warning.message).lower() for warning in captured_warnings)
+
+
+def test_smc_does_not_warn_when_active_kernel_settings_are_provided():
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        warnings.simplefilter("always")
+        BlackJAXSMCConfig(
+            inner_kernel="GRW", grw=BlackJAXSMCGRWConfig(initial_cov_scale=0.9)
+        )
+    assert not any(
+        "sub-config" in str(warning.message) for warning in captured_warnings
+    )
 
 
 def test_mala_step_size_scalar():
@@ -331,6 +361,34 @@ def test_hmc_defaults():
     assert cfg.step_size == 2e-3
     assert cfg.condition_matrix == 1.0
     assert cfg.n_leapfrog_steps == 10
+
+
+def test_smc_grw_subconfig_defaults():
+    cfg = BlackJAXSMCGRWConfig()
+    assert cfg.initial_cov_scale == 0.5
+    assert cfg.target_acceptance_rate == 0.234
+    assert cfg.scale_adaptation_gain == 3.0
+
+
+def test_smc_de_subconfig_has_no_fields():
+    assert BlackJAXSMCDEConfig().model_dump() == {}
+
+
+def test_smc_kernel_subconfig_coerced_from_dict():
+    cfg = BlackJAXSMCConfig(grw={"initial_cov_scale": 0.3}, de={})
+    assert isinstance(cfg.grw, BlackJAXSMCGRWConfig)
+    assert cfg.grw.initial_cov_scale == 0.3
+    assert isinstance(cfg.de, BlackJAXSMCDEConfig)
+
+
+def test_smc_kernel_subconfig_rejects_unknown_key():
+    with pytest.raises(ValidationError):
+        BlackJAXSMCConfig(grw={"step_size": 0.1})
+
+
+def test_smc_de_subconfig_rejects_unknown_key():
+    with pytest.raises(ValidationError):
+        BlackJAXSMCConfig(de={"mix": 0.5})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added selectable Gaussian random-walk (GRW) and differential-evolution (DE) kernels for the BlackJAX SMC sampler.
  - Added DE sampling with checkpointing, resumption, diagnostics and evidence estimation.
  - Reorganised GRW settings into a dedicated configuration section.
  - Increased the default particle count from 2,000 to 5,000.
  - Expanded CLI documentation for the new options.

- **Bug Fixes**
  - Checkpoints now validate the selected kernel.
  - DE sampling requires at least three particles.
  - Explicitly setting checkpointing to null keeps it disabled.
  - Resolved configurations omit inactive kernel settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->